### PR TITLE
fix: pinecone describe_index_stats response

### DIFF
--- a/apps/web/src/lib/vector-store/pinecone.ts
+++ b/apps/web/src/lib/vector-store/pinecone.ts
@@ -122,12 +122,12 @@ export class Pinecone {
   }
 
   async getDimensions() {
-    const response = await this.makeRequest<{ dimensions: number }>(
+    const response = await this.makeRequest<{ dimension: number }>(
       "GET",
       "/describe_index_stats",
       undefined,
       { includeBody: false },
     );
-    return response.dimensions;
+    return response.dimension;
   }
 }


### PR DESCRIPTION
https://docs.pinecone.io/reference/api/2025-04/data-plane/describeindexstats

`describe_index_stats` return `dimension`, not `dimensions`