### PR TITLE
Update default search mode

### DIFF
--- a/apps/web/src/lib/agentic/search.ts
+++ b/apps/web/src/lib/agentic/search.ts
@@ -55,7 +55,7 @@ export async function agenticSearch({
             ? [
                 {
                   query: lastMessage,
-                  type: "semantic",
+                  type: "semantic" as const,
                 },
               ]
             : []),
@@ -77,6 +77,9 @@ export async function agenticSearch({
 
           const queryResult = await queryVectorStore({
             query: query.query,
+            mode: queryOptions.vectorStore.supportsKeyword()
+              ? query.type
+              : undefined,
             rerank: { model: "cohere:rerank-v3.5", limit: 15 },
             includeMetadata: true,
             ...queryOptions,

--- a/apps/web/src/schemas/api/query.ts
+++ b/apps/web/src/schemas/api/query.ts
@@ -54,6 +54,7 @@ export const baseQueryVectorStoreSchema = z.object({
       "Whether to include metadata in the results. Defaults to `true`.",
     ),
   keywordFilter: z.string().optional(),
+  // TODO: add hybrid
   mode: z.enum(["semantic", "keyword"]).optional().default("semantic"),
 });
 

--- a/packages/engine/src/vector-store/common/vector-store.ts
+++ b/packages/engine/src/vector-store/common/vector-store.ts
@@ -82,4 +82,6 @@ export abstract class VectorStore<Filter = VectorFilter> {
   abstract deleteNamespace(): Promise<{ deleted?: number }>;
 
   abstract getDimensions(): Promise<number | "ANY">;
+
+  abstract supportsKeyword(): boolean;
 }

--- a/packages/engine/src/vector-store/pinecone/index.ts
+++ b/packages/engine/src/vector-store/pinecone/index.ts
@@ -117,4 +117,8 @@ export class Pinecone implements VectorStore<PineconeVectorFilter> {
     const response = await this.client.describeIndexStats();
     return response.dimension!;
   }
+
+  supportsKeyword() {
+    return false;
+  }
 }

--- a/packages/engine/src/vector-store/query.ts
+++ b/packages/engine/src/vector-store/query.ts
@@ -10,11 +10,13 @@ export type QueryVectorStoreOptions = Omit<VectorStoreQueryOptions, "mode"> & {
   embeddingModel: EmbeddingModel;
   vectorStore: VectorStore;
   rerank?: false | { model?: RerankingModel; limit?: number };
+  mode?: VectorStoreQueryOptions["mode"]["type"];
 };
 
 export const queryVectorStore = async ({
   embeddingModel,
   vectorStore,
+  mode = "semantic",
   ...options
 }: QueryVectorStoreOptions) => {
   const embedding = await embed({
@@ -25,7 +27,7 @@ export const queryVectorStore = async ({
   // TODO: track usage
   const results = await vectorStore.query({
     mode: {
-      type: "hybrid",
+      type: mode,
       vector: embedding.embedding,
       text: options.query,
     },

--- a/packages/engine/src/vector-store/turbopuffer/index.ts
+++ b/packages/engine/src/vector-store/turbopuffer/index.ts
@@ -249,4 +249,8 @@ export class Turbopuffer implements VectorStore<TurbopufferVectorFilter> {
 
     return "ANY" as const;
   }
+
+  supportsKeyword() {
+    return true;
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Search now intelligently routes between semantic and keyword modes based on your configured search backend’s capabilities.
  - Default search mode is semantic; keyword mode is used only when supported and explicitly requested.
- Bug Fixes
  - Prevents keyword searches when they’re disabled in your space settings, returning a clear error instead of failing silently.
  - More consistent handling of filters and metadata across search modes.
- Refactor
  - Improved internal search-mode detection and routing for greater reliability without changing the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->