### PR TITLE
Add endpoints for downloading document chunks and files

### DIFF
--- a/apps/web/src/app/api/(public-api)/v1/namespace/[namespaceId]/documents/[documentId]/chunks-download-url/route.ts
+++ b/apps/web/src/app/api/(public-api)/v1/namespace/[namespaceId]/documents/[documentId]/chunks-download-url/route.ts
@@ -1,0 +1,61 @@
+import { AgentsetApiError } from "@/lib/api/errors";
+import { withNamespaceApiHandler } from "@/lib/api/handler";
+import { makeApiSuccessResponse } from "@/lib/api/response";
+
+import { DocumentStatus } from "@agentset/db";
+import { db } from "@agentset/db/client";
+import { presignChunksDownloadUrl } from "@agentset/storage";
+import { normalizeId } from "@agentset/utils";
+
+export const POST = withNamespaceApiHandler(
+  async ({ params, namespace, headers }) => {
+    const documentId = normalizeId(params.documentId ?? "", "doc_");
+    if (!documentId) {
+      throw new AgentsetApiError({
+        code: "bad_request",
+        message: "Invalid document ID",
+      });
+    }
+
+    const document = await db.document.findUnique({
+      where: {
+        id: documentId,
+        namespaceId: namespace.id,
+      },
+      select: { id: true, status: true },
+    });
+
+    if (!document) {
+      throw new AgentsetApiError({
+        code: "not_found",
+        message: "Document not found",
+      });
+    }
+
+    if (document.status !== DocumentStatus.COMPLETED) {
+      throw new AgentsetApiError({
+        code: "bad_request",
+        message: "Chunks are only available for completed documents",
+      });
+    }
+
+    const url = await presignChunksDownloadUrl(namespace.id, document.id);
+    if (!url) {
+      throw new AgentsetApiError({
+        code: "not_found",
+        message: "Chunks file not found",
+      });
+    }
+
+    return makeApiSuccessResponse({
+      data: { url },
+      headers,
+    });
+  },
+  {
+    logging: {
+      routeName:
+        "POST /v1/namespace/[namespaceId]/documents/[documentId]/chunks-download-url",
+    },
+  },
+);

--- a/apps/web/src/app/api/(public-api)/v1/namespace/[namespaceId]/documents/[documentId]/file-download-url/route.ts
+++ b/apps/web/src/app/api/(public-api)/v1/namespace/[namespaceId]/documents/[documentId]/file-download-url/route.ts
@@ -1,0 +1,56 @@
+import { AgentsetApiError } from "@/lib/api/errors";
+import { withNamespaceApiHandler } from "@/lib/api/handler";
+import { makeApiSuccessResponse } from "@/lib/api/response";
+
+import { db } from "@agentset/db/client";
+import { presignGetUrl } from "@agentset/storage";
+import { normalizeId } from "@agentset/utils";
+
+export const POST = withNamespaceApiHandler(
+  async ({ params, namespace, headers }) => {
+    const documentId = normalizeId(params.documentId ?? "", "doc_");
+    if (!documentId) {
+      throw new AgentsetApiError({
+        code: "bad_request",
+        message: "Invalid document ID",
+      });
+    }
+
+    const document = await db.document.findUnique({
+      where: {
+        id: documentId,
+        namespaceId: namespace.id,
+      },
+      select: { id: true, name: true, source: true },
+    });
+
+    if (!document) {
+      throw new AgentsetApiError({
+        code: "not_found",
+        message: "Document not found",
+      });
+    }
+
+    if (document.source.type !== "MANAGED_FILE") {
+      throw new AgentsetApiError({
+        code: "bad_request",
+        message: "File download is only available for managed files",
+      });
+    }
+
+    const { url } = await presignGetUrl(document.source.key, {
+      fileName: document.name ?? undefined,
+    });
+
+    return makeApiSuccessResponse({
+      data: { url },
+      headers,
+    });
+  },
+  {
+    logging: {
+      routeName:
+        "POST /v1/namespace/[namespaceId]/documents/[documentId]/file-download-url",
+    },
+  },
+);

--- a/apps/web/src/openapi/v1/documents/get-chunks-download-url.ts
+++ b/apps/web/src/openapi/v1/documents/get-chunks-download-url.ts
@@ -1,0 +1,33 @@
+import type { ZodOpenApiOperationObject } from "zod-openapi";
+import { openApiErrorResponses, successSchema } from "@/openapi/responses";
+import { z } from "zod/v4";
+
+import { makeCodeSamples, ts } from "../code-samples";
+import { documentIdPathSchema, namespaceIdPathSchema } from "../utils";
+
+export const getChunksDownloadUrl: ZodOpenApiOperationObject = {
+  operationId: "getChunksDownloadUrl",
+  "x-speakeasy-name-override": "getChunksDownloadUrl",
+  summary: "Get chunks download URL",
+  description:
+    "Get a presigned download URL for a document's chunks. Only available for completed documents.",
+  parameters: [namespaceIdPathSchema, documentIdPathSchema],
+  responses: {
+    "200": {
+      description: "The presigned download URL for the chunks",
+      content: {
+        "application/json": {
+          schema: successSchema(z.object({ url: z.string() })),
+        },
+      },
+    },
+    ...openApiErrorResponses,
+  },
+  tags: ["Documents"],
+  security: [{ token: [] }],
+  ...makeCodeSamples(ts`
+const { url } = await ns.documents.getChunksDownloadUrl("doc_123");
+const data = await (await fetch(url)).json();
+console.log(data);
+`),
+};

--- a/apps/web/src/openapi/v1/documents/get-file-download-url.ts
+++ b/apps/web/src/openapi/v1/documents/get-file-download-url.ts
@@ -28,6 +28,6 @@ export const getFileDownloadUrl: ZodOpenApiOperationObject = {
   ...makeCodeSamples(ts`
 const { url } = await ns.documents.getFileDownloadUrl("doc_123");
 const file = await fetch(url);
-fs.writeFileSync("file.pdf", await file.arrayBuffer());
+fs.writeFileSync("file.pdf", Buffer.from(await file.arrayBuffer()));
 `),
 };

--- a/apps/web/src/openapi/v1/documents/get-file-download-url.ts
+++ b/apps/web/src/openapi/v1/documents/get-file-download-url.ts
@@ -1,0 +1,33 @@
+import type { ZodOpenApiOperationObject } from "zod-openapi";
+import { openApiErrorResponses, successSchema } from "@/openapi/responses";
+import { z } from "zod/v4";
+
+import { makeCodeSamples, ts } from "../code-samples";
+import { documentIdPathSchema, namespaceIdPathSchema } from "../utils";
+
+export const getFileDownloadUrl: ZodOpenApiOperationObject = {
+  operationId: "getFileDownloadUrl",
+  "x-speakeasy-name-override": "getFileDownloadUrl",
+  summary: "Get file download URL",
+  description:
+    "Get a presigned download URL for a document's source file. Only available for documents with source type MANAGED_FILE.",
+  parameters: [namespaceIdPathSchema, documentIdPathSchema],
+  responses: {
+    "200": {
+      description: "The presigned download URL for the file",
+      content: {
+        "application/json": {
+          schema: successSchema(z.object({ url: z.string() })),
+        },
+      },
+    },
+    ...openApiErrorResponses,
+  },
+  tags: ["Documents"],
+  security: [{ token: [] }],
+  ...makeCodeSamples(ts`
+const { url } = await ns.documents.getFileDownloadUrl("doc_123");
+const file = await fetch(url);
+fs.writeFileSync("file.pdf", await file.arrayBuffer());
+`),
+};

--- a/apps/web/src/openapi/v1/documents/index.ts
+++ b/apps/web/src/openapi/v1/documents/index.ts
@@ -1,7 +1,9 @@
 import type { ZodOpenApiPathsObject } from "zod-openapi";
 
 import { deleteDocument } from "./delete-document";
+import { getChunksDownloadUrl } from "./get-chunks-download-url";
 import { getDocument } from "./get-document";
+import { getFileDownloadUrl } from "./get-file-download-url";
 import { listDocuments } from "./list-documents";
 
 export const documentsPaths: ZodOpenApiPathsObject = {
@@ -11,5 +13,11 @@ export const documentsPaths: ZodOpenApiPathsObject = {
   "/v1/namespace/{namespaceId}/documents/{documentId}": {
     get: getDocument,
     delete: deleteDocument,
+  },
+  "/v1/namespace/{namespaceId}/documents/{documentId}/chunks-download-url": {
+    post: getChunksDownloadUrl,
+  },
+  "/v1/namespace/{namespaceId}/documents/{documentId}/file-download-url": {
+    post: getFileDownloadUrl,
   },
 };


### PR DESCRIPTION
- Implement POST /v1/namespace/[namespaceId]/documents/[documentId]/chunks-download-url to generate presigned URLs for document chunks, available only for completed documents.
- Implement POST /v1/namespace/[namespaceId]/documents/[documentId]/file-download-url to generate presigned URLs for managed files.
- Update OpenAPI specifications to include new endpoints and their respective response schemas.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two new `POST` endpoints for generating presigned S3 download URLs — one for a document's processed chunks JSON file and one for the document's original managed source file — along with their OpenAPI specs. 

The implementation is mostly solid, following existing project conventions. However, two issues require attention:

1. **Syntax error in OpenAPI code sample**: The TypeScript example in `get-file-download-url.ts` calls `fs.writeFileSync("file.pdf", await file.arrayBuffer())`, but `fs.writeFileSync` requires `NodeJS.ArrayBufferView` (not raw `ArrayBuffer`). This will throw a `TypeError` at runtime. Should wrap with `Buffer.from()`.

2. **Missing existence check**: The `file-download-url` endpoint generates presigned URLs without verifying the file exists in S3 first. Unlike `chunks-download-url`, which calls `presignChunksDownloadUrl` (which internally checks existence), this endpoint will return `200 OK` with a URL that clients cannot actually use if the underlying S3 object is absent or has been deleted.

The `chunks-download-url` route is well-implemented and properly handles the missing file case.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing the syntax error in the code sample and adding an existence check to the file-download-url endpoint.
- Two concrete issues identified: (1) TypeScript code sample in OpenAPI spec will fail at runtime with a TypeError, breaking developer experience; (2) Missing file-existence check creates behavioral inconsistency between similar endpoints and will return unusable URLs when S3 objects are absent or deleted. Neither is a security issue, but both are user-facing correctness problems that should be resolved before merge.
- apps/web/src/app/api/(public-api)/v1/namespace/[namespaceId]/documents/[documentId]/file-download-url/route.ts and apps/web/src/openapi/v1/documents/get-file-download-url.ts

<sub>Last reviewed commit: ce031c9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->