### PR TITLE
feat(emails): send 'Your data is ready!' email after ingest completes

### DIFF
--- a/packages/emails/src/index.ts
+++ b/packages/emails/src/index.ts
@@ -10,3 +10,4 @@ export { default as WebhookAddedEmail } from "./templates/webhook-added";
 export { default as WebhookFailedEmail } from "./templates/webhook-failed";
 export { default as WebhookDisabledEmail } from "./templates/webhook-disabled";
 export { default as DataReadyEmail } from "./templates/data-ready-email";
+export { default as DataProcessingFailedEmail } from "./templates/data-processing-failed-email";

--- a/packages/emails/src/index.ts
+++ b/packages/emails/src/index.ts
@@ -9,3 +9,4 @@ export { default as OTPEmail } from "./templates/email-otp";
 export { default as WebhookAddedEmail } from "./templates/webhook-added";
 export { default as WebhookFailedEmail } from "./templates/webhook-failed";
 export { default as WebhookDisabledEmail } from "./templates/webhook-disabled";
+export { default as DataReadyEmail } from "./templates/data-ready-email";

--- a/packages/emails/src/templates/data-processing-failed-email.tsx
+++ b/packages/emails/src/templates/data-processing-failed-email.tsx
@@ -1,0 +1,68 @@
+import { Heading, Section, Text } from "@react-email/components";
+
+import { Button } from "../components/button";
+import { DefaultLayout } from "../components/default-layout";
+
+export function DataProcessingFailedEmail({
+  email = "john@doe.com",
+  namespace = {
+    name: "My Namespace",
+    slug: "my-namespace",
+  },
+  organization = {
+    name: "Acme, Inc",
+    slug: "acme",
+  },
+  error = "Failed to process documents",
+  domain = "https://app.agentset.ai",
+}: {
+  email: string;
+  namespace: {
+    name: string;
+    slug: string;
+  };
+  organization: {
+    name: string;
+    slug: string;
+  };
+  error: string;
+  domain?: string;
+}) {
+  return (
+    <DefaultLayout
+      preview="There was an issue processing your data"
+      footer={{ email, domain }}
+    >
+      <Heading className="mx-0 my-7 p-0 text-xl font-medium text-black">
+        There was an issue processing your data
+      </Heading>
+
+      <Text className="text-sm leading-6 text-black">
+        <strong>{namespace.name}</strong> on{" "}
+        <a href="https://agentset.ai" className="text-black underline">
+          agentset.ai
+        </a>{" "}
+        ran into an issue while processing your data.
+      </Text>
+
+      <Text className="text-sm leading-6 text-black">
+        <strong>Error:</strong> {error}
+      </Text>
+
+      <Text className="text-sm leading-6 text-black">
+        Head over to your documents page to review the details and retry if
+        needed.
+      </Text>
+
+      <Section className="my-6">
+        <Button
+          href={`${domain}/${organization.slug}/${namespace.slug}/documents`}
+        >
+          View Documents
+        </Button>
+      </Section>
+    </DefaultLayout>
+  );
+}
+
+export default DataProcessingFailedEmail;

--- a/packages/emails/src/templates/data-ready-email.tsx
+++ b/packages/emails/src/templates/data-ready-email.tsx
@@ -1,0 +1,76 @@
+import { Heading, Section, Text } from "@react-email/components";
+
+import { Button } from "../components/button";
+import { DefaultLayout } from "../components/default-layout";
+
+export function DataReadyEmail({
+  email = "john@doe.com",
+  namespace = {
+    name: "My Namespace",
+    slug: "my-namespace",
+  },
+  organization = {
+    name: "Acme, Inc",
+    slug: "acme",
+  },
+  domain = "https://app.agentset.ai",
+}: {
+  email: string;
+  namespace: {
+    name: string;
+    slug: string;
+  };
+  organization: {
+    name: string;
+    slug: string;
+  };
+  domain?: string;
+}) {
+  return (
+    <DefaultLayout preview="Your data is ready!" footer={{ email, domain }}>
+      <Heading className="mx-0 my-7 p-0 text-xl font-medium text-black">
+        Your data is ready!
+      </Heading>
+
+      <Text className="text-sm leading-6 text-black">
+        <strong>{namespace.name}</strong> on{" "}
+        <a href="https://agentset.ai" className="text-black underline">
+          agentset.ai
+        </a>{" "}
+        just finished building your data.
+      </Text>
+
+      <Text className="text-sm leading-6 text-black">
+        Jump in and start chatting. Tell your namespace what you want to find,
+        and get answers from your documents.
+      </Text>
+
+      <Text className="text-sm leading-6 text-black">
+        A few tips to get you started:
+      </Text>
+
+      <Text className="ml-1 text-sm leading-4 text-black">
+        ◆ Start small. Try one simple question first to see how it works.
+      </Text>
+
+      <Text className="ml-1 text-sm leading-4 text-black">
+        ◆ Be specific. &quot;What are the key findings?&quot; beats &quot;tell
+        me stuff.&quot;
+      </Text>
+
+      <Text className="ml-1 text-sm leading-4 text-black">
+        ◆ Refine as you go. Follow up to dig deeper into any answer.
+      </Text>
+
+      <Section className="my-6">
+        <Button
+          href={`${domain}/${organization.slug}/${namespace.slug}/playground`}
+        >
+          Open Playground
+        </Button>
+      </Section>
+    </DefaultLayout>
+  );
+}
+
+export default DataReadyEmail;

--- a/packages/jobs/src/tasks/ingest.ts
+++ b/packages/jobs/src/tasks/ingest.ts
@@ -27,7 +27,11 @@ import {
   emitIngestJobWebhook,
 } from "../webhook";
 import { processDocument } from "./process-document";
-import { DataReadyEmail, sendEmail } from "@agentset/emails";
+import {
+  DataProcessingFailedEmail,
+  DataReadyEmail,
+  sendEmail,
+} from "@agentset/emails";
 import { getOrganizationOwner } from "@agentset/webhooks/server";
 
 const BATCH_SIZE = 30;
@@ -603,32 +607,32 @@ export const ingestJob = schemaTask({
       },
     });
 
-    // Send "Your data is ready!" email when all processing in the namespace is done
-    if (!jobFailed) {
-      try {
-        const activeJobCount = await db.ingestJob.count({
-          where: {
-            namespaceId: ingestionJob.namespace.id,
-            id: { not: ingestionJob.id },
-            status: {
-              in: [
-                IngestJobStatus.BACKLOG,
-                IngestJobStatus.QUEUED,
-                IngestJobStatus.QUEUED_FOR_RESYNC,
-                IngestJobStatus.PRE_PROCESSING,
-                IngestJobStatus.PROCESSING,
-              ],
-            },
+    // Send notification email when all processing in the namespace is done
+    try {
+      const activeJobCount = await db.ingestJob.count({
+        where: {
+          namespaceId: ingestionJob.namespace.id,
+          id: { not: ingestionJob.id },
+          status: {
+            in: [
+              IngestJobStatus.BACKLOG,
+              IngestJobStatus.QUEUED,
+              IngestJobStatus.QUEUED_FOR_RESYNC,
+              IngestJobStatus.PRE_PROCESSING,
+              IngestJobStatus.PROCESSING,
+            ],
           },
+        },
+      });
+
+      if (activeJobCount === 0) {
+        const owner = await getOrganizationOwner({
+          db,
+          organizationId: ingestionJob.namespace.organization.id,
         });
 
-        if (activeJobCount === 0) {
-          const owner = await getOrganizationOwner({
-            db,
-            organizationId: ingestionJob.namespace.organization.id,
-          });
-
-          if (owner) {
+        if (owner) {
+          if (!jobFailed) {
             await sendEmail({
               email: owner.email,
               subject: "Your data is ready!",
@@ -642,11 +646,26 @@ export const ingestJob = schemaTask({
               }),
               variant: "notifications",
             });
+          } else {
+            await sendEmail({
+              email: owner.email,
+              subject: "There was an issue processing your data",
+              react: DataProcessingFailedEmail({
+                email: owner.email,
+                namespace: {
+                  name: ingestionJob.namespace.name,
+                  slug: ingestionJob.namespace.slug,
+                },
+                organization: owner.organization,
+                error: jobError || "Failed to process documents",
+              }),
+              variant: "notifications",
+            });
           }
         }
-      } catch {
-        // Email notification is best-effort — don't fail the ingest job
       }
+    } catch {
+      // Email notification is best-effort — don't fail the ingest job
     }
 
     return {

--- a/packages/jobs/src/tasks/ingest.ts
+++ b/packages/jobs/src/tasks/ingest.ts
@@ -27,6 +27,8 @@ import {
   emitIngestJobWebhook,
 } from "../webhook";
 import { processDocument } from "./process-document";
+import { DataReadyEmail, sendEmail } from "@agentset/emails";
+import { getOrganizationOwner } from "@agentset/webhooks/server";
 
 const BATCH_SIZE = 30;
 
@@ -95,6 +97,8 @@ export const ingestJob = schemaTask({
         namespace: {
           select: {
             id: true,
+            slug: true,
+            name: true,
             embeddingConfig: true,
             vectorStoreConfig: true,
             organization: {
@@ -598,6 +602,52 @@ export const ingestJob = schemaTask({
         organizationId: ingestionJob.namespace.organization.id,
       },
     });
+
+    // Send "Your data is ready!" email when all processing in the namespace is done
+    if (!jobFailed) {
+      try {
+        const activeJobCount = await db.ingestJob.count({
+          where: {
+            namespaceId: ingestionJob.namespace.id,
+            id: { not: ingestionJob.id },
+            status: {
+              in: [
+                IngestJobStatus.BACKLOG,
+                IngestJobStatus.QUEUED,
+                IngestJobStatus.QUEUED_FOR_RESYNC,
+                IngestJobStatus.PRE_PROCESSING,
+                IngestJobStatus.PROCESSING,
+              ],
+            },
+          },
+        });
+
+        if (activeJobCount === 0) {
+          const owner = await getOrganizationOwner({
+            db,
+            organizationId: ingestionJob.namespace.organization.id,
+          });
+
+          if (owner) {
+            await sendEmail({
+              email: owner.email,
+              subject: "Your data is ready!",
+              react: DataReadyEmail({
+                email: owner.email,
+                namespace: {
+                  name: ingestionJob.namespace.name,
+                  slug: ingestionJob.namespace.slug,
+                },
+                organization: owner.organization,
+              }),
+              variant: "notifications",
+            });
+          }
+        }
+      } catch {
+        // Email notification is best-effort — don't fail the ingest job
+      }
+    }
 
     return {
       ingestionJobId: ingestionJob.id,


### PR DESCRIPTION
## Summary

- **New email template** (`data-ready-email.tsx`) notifying users when their uploaded data finishes processing, with tips and an "Open Playground" CTA
- **Email is sent only when all ingest jobs in the namespace are done** — no email if other jobs are still processing
- **Best-effort delivery** — email sending is wrapped in try/catch so it never breaks the ingest job

## Changes

- `packages/emails/src/templates/data-ready-email.tsx` — New React Email template using existing `DefaultLayout`, `Button`, and `Footer` components. Includes namespace name, getting-started tips, and a link to the playground.
- `packages/emails/src/index.ts` — Export `DataReadyEmail`
- `packages/jobs/src/tasks/ingest.ts`:
  - Added `slug` and `name` to the namespace Prisma select
  - After ingest job completion + webhook emission, checks if no other active jobs remain in the namespace
  - If all clear, sends the notification email to the org owner via `getOrganizationOwner()` with `variant: "notifications"`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a "Your data is ready!" transactional email that fires after an ingest job completes, using an existing `DefaultLayout`/`Button`/`Footer` component system and a new `DataReadyEmail` React Email template. The overall approach is sound and follows established patterns in the codebase, but there is a notable race condition in the delivery logic.

- **Race condition in `ingest.ts`**: The `activeJobCount` check is not atomic with the job-status transaction. If two jobs in the same namespace complete concurrently, both can observe `activeJobCount === 0` after updating their own status and each send the notification email, resulting in duplicate messages to the owner.
- **Unused `organization.name` field** in `DataReadyEmail`: the prop type declares `name` but it is never rendered in the template; only `slug` is actually used.
- **Import ordering** in `ingest.ts`: the two new `@agentset/*` imports are appended after local `./` imports, breaking the convention used throughout the rest of the file.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for functionality, but the race condition should be addressed to prevent duplicate emails being sent when namespace jobs complete concurrently.
- The core feature is well-implemented and follows existing patterns; email sending is correctly wrapped in a best-effort try/catch. However, the non-atomic `activeJobCount` check introduces a real risk of duplicate emails when namespace jobs complete concurrently, which is a user-facing correctness issue that warrants a fix. Additionally, minor code organization issues (import ordering and unused type field) should be cleaned up.
- packages/jobs/src/tasks/ingest.ts — the email-trigger logic needs an atomic or idempotent mechanism to prevent duplicate sends, and import ordering should be corrected.

<sub>Last reviewed commit: 8d10761</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Rule from `dashboard` - Comprehensive rules to help you write advanced Trigger.dev tasks ([source](https://app.greptile.com/review/custom-context?memory=7bcc4fc8-51f5-4a30-b698-fbf44c9408ca))
- Rule from `dashboard` - Guidelines for writing clean, maintainable, and human-readable code. Apply these rules when writing ... ([source](https://app.greptile.com/review/custom-context?memory=ae3f5924-b837-4792-9dae-0bd929e9f8dd))

<!-- /greptile_comment -->