### PR TITLE
Update cancellation email copy

### DIFF
--- a/apps/web/src/app/api/(internal-api)/stripe/webhook/utils.ts
+++ b/apps/web/src/app/api/(internal-api)/stripe/webhook/utils.ts
@@ -48,7 +48,7 @@ export async function sendCancellationFeedback({
           from: "Abdellatif <contact@agentset.ai>",
           replyTo: "contact@agentset.ai",
           subject: "Feedback for Agentset.ai?",
-          text: `Hey ${owner.name ? owner.name.split(" ")[0] : "there"}!\n\nSaw you canceled your Agentset subscription${reasonText ? ` and mentioned that ${reasonText}` : ""} – do you mind sharing if there's anything we could've done better on our side?\n\nWe're always looking to improve our product offering so any feedback would be greatly appreciated!\n\nThank you so much in advance!\n\nBest,\nAbdellatif\nCo-founder, Agentset.ai`,
+          text: `Hey ${owner.name ? owner.name.split(" ")[0] : "there"}!\n\nSaw you canceled your Agentset subscription${reasonText ? ` and mentioned that ${reasonText}` : ""} – do you mind sharing if there's anything we could've done better on our side?\n\nWe're always looking to improve our product offering so any feedback would be greatly appreciated.\n\nAbdellatif\nCo-founder, Agentset`,
         }),
     ),
   );

--- a/apps/web/src/app/api/(internal-api)/stripe/webhook/utils.ts
+++ b/apps/web/src/app/api/(internal-api)/stripe/webhook/utils.ts
@@ -47,7 +47,7 @@ export async function sendCancellationFeedback({
           email: owner.email,
           from: "Abdellatif <contact@agentset.ai>",
           replyTo: "contact@agentset.ai",
-          subject: "Feedback for Agentset.ai?",
+          subject: "Feedback for Agentset?",
           text: `Hey ${owner.name ? owner.name.split(" ")[0] : "there"}!\n\nSaw you canceled your Agentset subscription${reasonText ? ` and mentioned that ${reasonText}` : ""} – do you mind sharing if there's anything we could've done better on our side?\n\nWe're always looking to improve our product offering so any feedback would be greatly appreciated.\n\nAbdellatif\nCo-founder, Agentset`,
         }),
     ),


### PR DESCRIPTION
## Summary
- Simplified the cancellation feedback email sign-off (removed "Thank you so much in advance!", "Best,", and ".ai" from "Agentset.ai")
- Removed trailing exclamation mark from the feedback request line

## Test plan
- [ ] Trigger a test subscription cancellation and verify the email copy

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR simplifies the copy in the cancellation feedback email sent via the Stripe webhook handler. The changes are purely cosmetic — no logic, data flow, or API behavior is altered.

**Changes made:**
- Removed `"Thank you so much in advance!\n\n"` and `"Best,\n"` from the email sign-off
- Changed `"Agentset.ai"` → `"Agentset"` in the co-founder sign-off line
- Changed the trailing `!` to `.` on the feedback request sentence

**Issue found:**
- The `subject` field still reads `"Feedback for Agentset.ai?"` while the body now uses `"Agentset"` — a minor inconsistency if the intent is to standardize the brand name across the email.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only changes static email copy with no impact on logic, data, or API behavior.
- The change is isolated to a single string literal in an email template. No logic, control flow, or external integrations are affected. The only note is a minor brand name inconsistency between the subject and body that the author may want to address.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/api/(internal-api)/stripe/webhook/utils.ts | Minor copy update to the cancellation feedback email: removed "Thank you so much in advance!", "Best,", and ".ai" from the sign-off, and softened the feedback request line from "!" to ".". Minor inconsistency: the `subject` field still says "Agentset.ai" while the body now reads "Agentset". |

</details>

<sub>Last reviewed commit: ["Update cancellation ..."](https://github.com/agentset-ai/agentset/commit/c82c3ff56e398b0ef01d587b7190d61538197ef3)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->