### PR TITLE
Update self-hosting guide link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The fastest way to get started with Agentset. Generous free tier with 1,000 page
 
 ### Self-host Agentset
 
-Follow our complete guide: https://docs.agentset.ai/open-source/self-hosting
+Follow our complete guide: https://docs.agentset.ai/open-source/prerequisites
 
 ## Quick Start (Local Development)
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the self-hosting guide link in `README.md` from `https://docs.agentset.ai/open-source/self-hosting` to `https://docs.agentset.ai/open-source/prerequisites`, likely reflecting a restructuring of the documentation site where the self-hosting content now begins at a prerequisites page.

- The change is minimal and low-risk, touching only a single URL in the README
- No other references to the old `self-hosting` path were found in the repository
- The new `/prerequisites` path suggests the self-hosting docs may have been split into multiple pages, with prerequisites as the entry point

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a single-line documentation URL update with no impact on application code.
- The change is minimal, touches only a README URL, and no other references to the old path exist in the codebase. No functional code is affected.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Updates the self-hosting guide link from `/open-source/self-hosting` to `/open-source/prerequisites`, reflecting a restructuring of the documentation. |

</details>

<sub>Last reviewed commit: ["Update self-hosting ..."](https://github.com/agentset-ai/agentset/commit/1c2b19b432a362db2db4dbace92a393a075e7e2b)</sub>

<!-- /greptile_comment -->