### PR TITLE
Add schedule demo link to login subtitle

### DIFF
--- a/apps/web/src/app/app.agentset.ai/login/login-form.tsx
+++ b/apps/web/src/app/app.agentset.ai/login/login-form.tsx
@@ -182,7 +182,13 @@ export function LoginForm({
               </div>
               <h1 className="mt-8 text-base/6 font-medium">Welcome back!</h1>
               <p className="mt-1 text-sm/5 text-gray-600">
-                Sign in to your account to continue.
+                Don't have an account?{" "}
+                <a
+                  href="https://agentset.ai/schedule-demo"
+                  className="font-medium text-gray-900 underline underline-offset-2 hover:text-gray-700"
+                >
+                  Schedule a demo
+                </a>
               </p>
 
               <div className="mt-8 space-y-3">


### PR DESCRIPTION
## Summary
- Replace the "Sign in to your account to continue." subtitle on the main login page with a "Don't have an account? Schedule a demo" link pointing to https://agentset.ai/schedule-demo.

## Test plan
- [ ] Visit the login page and confirm the new subtitle renders with the link
- [ ] Click the link and verify it opens the schedule demo page

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the static \"Sign in to your account to continue.\" subtitle on the login page with a \"Don't have an account? Schedule a demo\" link pointing to `https://agentset.ai/schedule-demo`. The only finding is a P2 suggestion to add `target=\"_blank\"` and `rel=\"noopener noreferrer\"` so the external link opens in a new tab instead of navigating users away from the login page.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the only finding is a minor UX suggestion about opening the external link in a new tab.

Single-file change with a straightforward copy update. The sole finding (missing target="_blank") is P2 and does not block correctness or security.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/app.agentset.ai/login/login-form.tsx | Replaced static subtitle text with an external "Schedule a demo" link; missing `target="_blank"` and `rel="noopener noreferrer"` on the anchor. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Add schedule demo link to login subtitle"](https://github.com/agentset-ai/agentset/commit/9fcf7d1743f9988e148f32e9cacccdc83ec05098) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28768577)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->