### PR TITLE
Trigger.dev fixes

### DIFF
--- a/packages/db/src/trigger.ts
+++ b/packages/db/src/trigger.ts
@@ -4,6 +4,15 @@ import { PrismaClient } from "../generated/client";
 
 export const createTriggerPrisma = () => {
   return new PrismaClient({
-    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL! }),
+    adapter: new PrismaPg({
+      connectionString: process.env.DATABASE_URL!,
+    }),
+    transactionOptions:
+      process.env.NODE_ENV === "development"
+        ? undefined
+        : {
+            maxWait: 7000,
+            timeout: 15000,
+          },
   });
 };

--- a/packages/jobs/src/tasks/meter-org-documents.ts
+++ b/packages/jobs/src/tasks/meter-org-documents.ts
@@ -13,7 +13,7 @@ import {
   meterOrgDocumentsBodySchema,
 } from "../schema";
 
-const BATCH_SIZE = 300;
+const BATCH_SIZE = 100; // stripe has a limit of 100 events per request
 
 export const meterOrgDocuments = schemaTask({
   id: METER_ORG_DOCUMENTS_JOB_ID,

--- a/packages/jobs/src/tasks/meter-org-documents.ts
+++ b/packages/jobs/src/tasks/meter-org-documents.ts
@@ -98,10 +98,10 @@ export const meterOrgDocuments = schemaTask({
         });
 
         const hasMore = documents.length > BATCH_SIZE;
-        const last = documents.at(-1) as
+        const items = hasMore ? documents.slice(0, BATCH_SIZE) : documents;
+        const last = items.at(-1) as
           | { id: string; createdAt: Date }
           | undefined;
-        const items = hasMore ? documents.slice(0, BATCH_SIZE) : documents;
 
         if (hasMore && last) {
           cursor = { id: last.id, createdAt: last.createdAt };


### PR DESCRIPTION
Update trigger configuration and adjust batch size for meterOrgDocuments task

- Added transaction options to Prisma client based on the environment.
- Reduced batch size for meterOrgDocuments to comply with Stripe's event limit.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces the Stripe metering batch size from 300 to 100 to comply with Stripe's per-request event limit, and adds extended Prisma transaction timeouts for non-development environments in the Trigger.dev client.

- **P1 — silent metering gap**: In `meter-org-documents.ts`, the cursor is set to the \"peek\" element (`documents[BATCH_SIZE]`) rather than the last item actually processed (`items[items.length - 1]`). Because the next page query uses a strict `lt` filter, every document at a batch boundary (position 101, 201, …) is never passed to Stripe. Reducing the batch size from 300 → 100 makes this 3× more frequent.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is — the cursor pagination bug silently under-meters documents on every page boundary, and reducing the batch size makes the gap more frequent.

There is a P1 data-integrity defect in the changed file: one document is silently skipped per 100-document page boundary due to the cursor being set to the peek element rather than the last processed item. The batch size reduction makes this happen more often than before.

packages/jobs/src/tasks/meter-org-documents.ts — cursor pagination logic needs to be fixed before merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/jobs/src/tasks/meter-org-documents.ts | Batch size reduced to 100 to respect Stripe's per-request event limit, but the cursor pagination logic sets the cursor to the peek element, silently skipping one document per page boundary. |
| packages/db/src/trigger.ts | Adds extended transaction timeouts for non-development environments; dev/prod inconsistency is minor but worth noting. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/jobs/src/tasks/meter-org-documents.ts`, line 100-104 ([link](https://github.com/agentset-ai/agentset/blob/7634733fc8adcb248abaca6a506ba74d3b809150/packages/jobs/src/tasks/meter-org-documents.ts#L100-L104)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Cursor set to peek item — one document skipped per page boundary**

   When `hasMore` is true, `last` is `documents[BATCH_SIZE]` (the 101st peek element), not the last item actually sent to Stripe. Because the next query uses a strict `lt` filter, `documents[BATCH_SIZE]` is excluded from all batches: it wasn't in `items` (which is `documents[0..BATCH_SIZE-1]`) and the next fetch starts strictly *before* it. Every document that lands at position 101, 201, 301, … in sorted order is silently never metered. Reducing `BATCH_SIZE` from 300 → 100 makes this happen 3× more frequently.

   Fix: set the cursor to the last item in `items` rather than the raw peek element:

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Update trigger configuration and adjust ..."](https://github.com/agentset-ai/agentset/commit/7634733fc8adcb248abaca6a506ba74d3b809150) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29170068)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->