### PR TITLE
docs: Add FAQ section

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,77 @@ MIT :)
 ---
 
 Made with ❤️ by the Agentset team.
+
+## FAQ
+
+### What is Agentset?
+
+Agentset is the open-source platform to build, evaluate, and ship production-ready RAG and agentic applications. It provides end-to-end tooling: ingestion, vector indexing, evaluation/benchmarks, chat playground, hosting, and a developer-friendly API.
+
+### How does Agentset compare to LangChain or LlamaIndex?
+
+- **Agentset**: Full RAG platform with ingestion, chunking, embeddings, retrieval, evaluation, chat playground, hosting, API, and SDKs
+- **LangChain**: Chain-based orchestration library, requires building your own RAG pipeline
+- **LlamaIndex**: Data framework for LLM apps, focused on indexing and retrieval
+
+Agentset provides a turnkey solution for RAG with built-in evaluation and production hosting.
+
+### What are the key features of Agentset?
+
+- **Turnkey RAG**: Ingestion, chunking, embeddings, and retrieval out of the box
+- **Model agnostic**: Works with your choice of LLM, embeddings, and vector DB
+- **Chat playground**: Message editing and citations
+- **Production hosting**: Preview links and custom domains
+- **API + typed SDKs**: OpenAPI spec included
+- **Built-in multi-tenancy**: Enterprise-ready
+
+### How do I get started with Agentset?
+
+**Agentset Cloud** (recommended for quick start):
+1. Sign up at https://app.agentset.ai/login
+2. No credit card required, 1,000 pages and 10,000 retrievals free tier
+
+**Self-host**:
+```bash
+# 1) Copy env and fill required values
+cp .env.example .env
+
+# 2) Install dependencies
+bun install
+
+# 3) Run database migrations
+bun db:deploy
+
+# 4) Start the app
+bun dev:web
+```
+
+### What tech stack does Agentset use?
+
+- TypeScript
+- Next.js
+- AI SDK
+- Prisma
+- Supabase
+- Trigger.dev
+
+### What LLM/embedding providers are supported?
+
+Agentset is model agnostic - works with your choice of:
+- OpenAI
+- Anthropic
+- Google Gemini
+- Local models (via compatible APIs)
+
+### How do I use the API?
+
+Agentset provides:
+- REST API with typed SDKs
+- OpenAPI spec for documentation
+- SDKs for popular languages
+
+### Where can I find help?
+
+- [Documentation](https://docs.agentset.ai)
+- [GitHub Issues](https://github.com/agentset-ai/agentset/issues)
+- [Discord](https://discord.com/invite/XNcrk6bv)


### PR DESCRIPTION
This PR adds a comprehensive FAQ section to the README.md, covering:

- What is Agentset
- Agentset vs LangChain/LlamaIndex comparison
- Key features (Turnkey RAG, Model agnostic, Chat playground, Production hosting, API + SDKs)
- Getting started guide (Agentset Cloud vs Self-host)
- Tech stack (TypeScript, Next.js, AI SDK, Prisma, Supabase, Trigger.dev)
- LLM/embedding providers support
- API usage
- Help resources (Docs, GitHub Issues, Discord)

This FAQ helps new users quickly understand Agentset's capabilities and how to get started with production-ready RAG.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR appends a new FAQ section to `README.md` covering what Agentset is, how it compares to alternatives, key features, getting started, tech stack, LLM providers, API usage, and help resources.

- The FAQ is inserted after the "Made with ❤️ by the Agentset team." closing line, which breaks the intended footer; it should appear before the License/footer.
- The "Self-host" answer in the FAQ shows the local development `bun dev:web` commands rather than pointing to the production self-hosting guide at `https://docs.agentset.ai/open-source/prerequisites`, which could mislead users attempting a real deployment.
- The "What is Agentset?" answer is a verbatim copy of the existing intro paragraph, creating a maintenance risk if the two descriptions drift.

<h3>Confidence Score: 3/5</h3>

The FAQ section is safe from a code perspective but contains a misleading self-hosting answer that would point production self-hosters to local dev instructions.

The self-host FAQ answer directs users to bun dev:web local-development commands without mentioning the dedicated production self-hosting guide, meaning anyone following that FAQ entry to deploy Agentset in production would be working from incorrect instructions.

README.md — specifically the Self-host code block inside the FAQ and the overall placement of the FAQ section after the closing footer.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| README.md | Adds a FAQ section after the closing footer; the self-host answer conflates local-dev commands with production deployment, the "What is Agentset?" answer duplicates the intro verbatim, and the section placement breaks the intended document ending. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `README.md`, line 99-107 ([link](https://github.com/agentset-ai/agentset/blob/680f3c5f6104ff6716e8ec2fa1c199e7eee96cd7/README.md#L99-L107)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> The FAQ section is placed after the `Made with ❤️ by the Agentset team.` closing line, which breaks the intended footer. Moving the FAQ before the License section (or at least before the closing footer) follows the conventional README structure.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["docs: Add FAQ section"](https://github.com/agentset-ai/agentset/commit/680f3c5f6104ff6716e8ec2fa1c199e7eee96cd7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32585129)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->