### PR TITLE
Limit file uploads to 5MB on the free plan

### DIFF
--- a/apps/web/src/app/api/(public-api)/v1/namespace/[namespaceId]/uploads/batch/route.ts
+++ b/apps/web/src/app/api/(public-api)/v1/namespace/[namespaceId]/uploads/batch/route.ts
@@ -7,19 +7,23 @@ import { createBatchUpload } from "@/services/uploads";
 import { z } from "zod/v4";
 
 export const POST = withNamespaceApiHandler(
-  async ({ namespace, headers, req }) => {
+  async ({ namespace, organization, headers, req }) => {
     const { files } = await batchUploadSchema.parseAsync(
       await parseRequestBody(req),
     );
 
     const result = await createBatchUpload({
       namespaceId: namespace.id,
+      plan: organization.plan,
       files,
     });
 
     if (!result.success) {
       throw new AgentsetApiError({
-        code: "internal_server_error",
+        code:
+          result.code === "file_too_large"
+            ? "rate_limit_exceeded"
+            : "internal_server_error",
         message: result.error,
       });
     }

--- a/apps/web/src/app/api/(public-api)/v1/namespace/[namespaceId]/uploads/route.ts
+++ b/apps/web/src/app/api/(public-api)/v1/namespace/[namespaceId]/uploads/route.ts
@@ -6,18 +6,22 @@ import { uploadFileSchema, UploadResultSchema } from "@/schemas/api/upload";
 import { createUpload } from "@/services/uploads";
 
 export const POST = withNamespaceApiHandler(
-  async ({ namespace, headers, req }) => {
+  async ({ namespace, organization, headers, req }) => {
     const { fileName, contentType, fileSize } =
       await uploadFileSchema.parseAsync(await parseRequestBody(req));
 
     const result = await createUpload({
       namespaceId: namespace.id,
+      plan: organization.plan,
       file: { fileName, contentType, fileSize },
     });
 
     if (!result.success) {
       throw new AgentsetApiError({
-        code: "internal_server_error",
+        code:
+          result.code === "file_too_large"
+            ? "rate_limit_exceeded"
+            : "internal_server_error",
         message: result.error,
       });
     }

--- a/apps/web/src/app/app.agentset.ai/(dashboard)/[slug]/[namespaceSlug]/documents/ingest-modal/files-form.tsx
+++ b/apps/web/src/app/app.agentset.ai/(dashboard)/[slug]/[namespaceSlug]/documents/ingest-modal/files-form.tsx
@@ -1,9 +1,13 @@
 import type { UseFormReturn } from "react-hook-form";
 import { useEffect } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useOrganization } from "@/hooks/use-organization";
 import { useUploadFiles } from "@/hooks/use-upload";
 import { useZodForm } from "@/hooks/use-zod-form";
 import { SUPPORTED_TYPES } from "@/lib/file-types";
+import { getMaxUploadSize, uploadSizeLimitMessage } from "@/lib/upload-limits";
+import { toast } from "sonner";
 import { z } from "zod/v4";
 
 import { MAX_UPLOAD_SIZE } from "@agentset/storage/constants";
@@ -23,6 +27,7 @@ import { FileUploader } from "@agentset/ui/file-uploader";
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -31,6 +36,7 @@ import {
 import { Input } from "@agentset/ui/input";
 import { Label } from "@agentset/ui/label";
 import { RadioGroup, RadioGroupItem } from "@agentset/ui/radio-group";
+import { formatBytes } from "@agentset/utils";
 import { configSchema } from "@agentset/validation";
 
 import type { BaseIngestFormProps } from "./shared";
@@ -157,6 +163,11 @@ const ModeField = ({ form }: { form: UseFormReturn<any> }) => {
 };
 
 export default function FilesForm({ onSuccess }: BaseIngestFormProps) {
+  const router = useRouter();
+  const { plan, slug } = useOrganization();
+  const isFree = isFreePlan(plan);
+  const maxUploadSize = getMaxUploadSize(plan);
+
   const form = useZodForm(filesSchema, {
     defaultValues: {
       name: "",
@@ -296,12 +307,62 @@ export default function FilesForm({ onSuccess }: BaseIngestFormProps) {
                       onValueChange={field.onChange}
                       maxFileCount={100}
                       multiple
-                      maxSize={MAX_UPLOAD_SIZE}
+                      maxSize={maxUploadSize}
                       progresses={progresses}
                       accept={ACCEPT}
                       disabled={isPending}
+                      onFilesReject={(rejections) => {
+                        const tooLarge = rejections.filter((rejection) =>
+                          rejection.errors.some(
+                            (error) => error.code === "file-too-large",
+                          ),
+                        );
+
+                        if (tooLarge.length > 0) {
+                          toast.error(
+                            uploadSizeLimitMessage(
+                              plan,
+                              tooLarge.map((rejection) => rejection.file.name),
+                            ),
+                            {
+                              id: "upload-size-limit",
+                              // keep the toast clickable while the ingest
+                              // dialog sets pointer-events: none on <body>
+                              style: { pointerEvents: "auto" },
+                              action: isFree
+                                ? {
+                                    label: "Upgrade",
+                                    onClick: () =>
+                                      router.push(`/${slug}/billing/upgrade`),
+                                  }
+                                : undefined,
+                            },
+                          );
+                        }
+
+                        rejections
+                          .filter((rejection) => !tooLarge.includes(rejection))
+                          .forEach((rejection) => {
+                            toast.error(
+                              `File ${rejection.file.name} was rejected`,
+                            );
+                          });
+                      }}
                     />
                   </FormControl>
+                  {isFree && (
+                    <FormDescription>
+                      The Free plan supports files up to{" "}
+                      {formatBytes(maxUploadSize)} each.{" "}
+                      <Link
+                        href={`/${slug}/billing/upgrade`}
+                        className="text-primary underline"
+                      >
+                        Upgrade to Pro
+                      </Link>{" "}
+                      to upload files up to {formatBytes(MAX_UPLOAD_SIZE)}.
+                    </FormDescription>
+                  )}
                   <FormMessage />
                 </FormItem>
               )}

--- a/apps/web/src/app/app.agentset.ai/(dashboard)/[slug]/[namespaceSlug]/documents/ingest-modal/files-form.tsx
+++ b/apps/web/src/app/app.agentset.ai/(dashboard)/[slug]/[namespaceSlug]/documents/ingest-modal/files-form.tsx
@@ -1,7 +1,6 @@
 import type { UseFormReturn } from "react-hook-form";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { useOrganization } from "@/hooks/use-organization";
 import { useUploadFiles } from "@/hooks/use-upload";
 import { useZodForm } from "@/hooks/use-zod-form";
@@ -27,7 +26,6 @@ import { FileUploader } from "@agentset/ui/file-uploader";
 import {
   Form,
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -163,10 +161,10 @@ const ModeField = ({ form }: { form: UseFormReturn<any> }) => {
 };
 
 export default function FilesForm({ onSuccess }: BaseIngestFormProps) {
-  const router = useRouter();
   const { plan, slug } = useOrganization();
   const isFree = isFreePlan(plan);
   const maxUploadSize = getMaxUploadSize(plan);
+  const [sizeError, setSizeError] = useState<string | null>(null);
 
   const form = useZodForm(filesSchema, {
     defaultValues: {
@@ -304,7 +302,10 @@ export default function FilesForm({ onSuccess }: BaseIngestFormProps) {
                   <FormControl>
                     <FileUploader
                       value={field.value}
-                      onValueChange={field.onChange}
+                      onValueChange={(files) => {
+                        setSizeError(null);
+                        field.onChange(files);
+                      }}
                       maxFileCount={100}
                       multiple
                       maxSize={maxUploadSize}
@@ -319,24 +320,11 @@ export default function FilesForm({ onSuccess }: BaseIngestFormProps) {
                         );
 
                         if (tooLarge.length > 0) {
-                          toast.error(
+                          setSizeError(
                             uploadSizeLimitMessage(
                               plan,
                               tooLarge.map((rejection) => rejection.file.name),
                             ),
-                            {
-                              id: "upload-size-limit",
-                              // keep the toast clickable while the ingest
-                              // dialog sets pointer-events: none on <body>
-                              style: { pointerEvents: "auto" },
-                              action: isFree
-                                ? {
-                                    label: "Upgrade",
-                                    onClick: () =>
-                                      router.push(`/${slug}/billing/upgrade`),
-                                  }
-                                : undefined,
-                            },
                           );
                         }
 
@@ -350,20 +338,25 @@ export default function FilesForm({ onSuccess }: BaseIngestFormProps) {
                       }}
                     />
                   </FormControl>
-                  {isFree && (
-                    <FormDescription>
-                      The Free plan supports files up to{" "}
-                      {formatBytes(maxUploadSize)} each.{" "}
-                      <Link
-                        href={`/${slug}/billing/upgrade`}
-                        className="text-primary underline"
-                      >
-                        Upgrade to Pro
-                      </Link>{" "}
-                      to upload files up to {formatBytes(MAX_UPLOAD_SIZE)}.
-                    </FormDescription>
-                  )}
-                  <FormMessage />
+                  <FormMessage>
+                    {sizeError && (
+                      <>
+                        {sizeError}{" "}
+                        {isFree && (
+                          <>
+                            <Link
+                              href={`/${slug}/billing/upgrade`}
+                              className="font-medium underline underline-offset-4"
+                            >
+                              Upgrade to Pro
+                            </Link>{" "}
+                            to upload files up to {formatBytes(MAX_UPLOAD_SIZE)}
+                            .
+                          </>
+                        )}
+                      </>
+                    )}
+                  </FormMessage>
                 </FormItem>
               )}
             />

--- a/apps/web/src/app/app.agentset.ai/(dashboard)/[slug]/[namespaceSlug]/documents/ingest-modal/files-form.tsx
+++ b/apps/web/src/app/app.agentset.ai/(dashboard)/[slug]/[namespaceSlug]/documents/ingest-modal/files-form.tsx
@@ -336,27 +336,28 @@ export default function FilesForm({ onSuccess }: BaseIngestFormProps) {
                             );
                           });
                       }}
+                      message={
+                        sizeError && (
+                          <p className="text-destructive-foreground text-sm">
+                            {sizeError}{" "}
+                            {isFree && (
+                              <>
+                                <Link
+                                  href={`/${slug}/billing/upgrade`}
+                                  className="font-medium underline underline-offset-4"
+                                >
+                                  Upgrade to Pro
+                                </Link>{" "}
+                                to upload files up to{" "}
+                                {formatBytes(MAX_UPLOAD_SIZE)}.
+                              </>
+                            )}
+                          </p>
+                        )
+                      }
                     />
                   </FormControl>
-                  <FormMessage>
-                    {sizeError && (
-                      <>
-                        {sizeError}{" "}
-                        {isFree && (
-                          <>
-                            <Link
-                              href={`/${slug}/billing/upgrade`}
-                              className="font-medium underline underline-offset-4"
-                            >
-                              Upgrade to Pro
-                            </Link>{" "}
-                            to upload files up to {formatBytes(MAX_UPLOAD_SIZE)}
-                            .
-                          </>
-                        )}
-                      </>
-                    )}
-                  </FormMessage>
+                  <FormMessage />
                 </FormItem>
               )}
             />

--- a/apps/web/src/hooks/use-upload.ts
+++ b/apps/web/src/hooks/use-upload.ts
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useTRPC } from "@/trpc/react";
 import { useMutation } from "@tanstack/react-query";
+import { TRPCClientError } from "@trpc/client";
 import { toast } from "sonner";
 
 const uploadWithProgress = (
@@ -83,8 +84,12 @@ export function useUploadFiles({ namespaceId }: { namespaceId: string }) {
           setUploadedFiles((prev) => [...prev, newEntry]);
         }),
       );
-    } catch {
-      toast.error("Failed to upload file!");
+    } catch (error) {
+      toast.error(
+        error instanceof TRPCClientError
+          ? error.message
+          : "Failed to upload file!",
+      );
     } finally {
       setProgresses({});
       setIsUploading(false);

--- a/apps/web/src/lib/upload-limits.ts
+++ b/apps/web/src/lib/upload-limits.ts
@@ -13,7 +13,11 @@ export const uploadSizeLimitMessage = (plan: string, fileNames: string[]) => {
     fileNames.length === 1
       ? `"${fileNames[0]}" exceeds`
       : `${fileNames.length} files exceed`;
-  const message = `${subject} the ${formatBytes(getMaxUploadSize(plan))} file size limit on the ${capitalize(plan)} plan.`;
+  return `${subject} the ${formatBytes(getMaxUploadSize(plan))} file size limit on the ${capitalize(plan)} plan.`;
+};
+
+export const uploadSizeLimitError = (plan: string, fileNames: string[]) => {
+  const message = uploadSizeLimitMessage(plan, fileNames);
 
   if (!isFreePlan(plan)) return message;
   return `${message} Upgrade to Pro to upload files up to ${formatBytes(MAX_UPLOAD_SIZE)}.`;

--- a/apps/web/src/lib/upload-limits.ts
+++ b/apps/web/src/lib/upload-limits.ts
@@ -1,0 +1,20 @@
+import {
+  FREE_PLAN_MAX_UPLOAD_SIZE,
+  MAX_UPLOAD_SIZE,
+} from "@agentset/storage/constants";
+import { isFreePlan } from "@agentset/stripe/plans";
+import { capitalize, formatBytes } from "@agentset/utils";
+
+export const getMaxUploadSize = (plan: string) =>
+  isFreePlan(plan) ? FREE_PLAN_MAX_UPLOAD_SIZE : MAX_UPLOAD_SIZE;
+
+export const uploadSizeLimitMessage = (plan: string, fileNames: string[]) => {
+  const subject =
+    fileNames.length === 1
+      ? `"${fileNames[0]}" exceeds`
+      : `${fileNames.length} files exceed`;
+  const message = `${subject} the ${formatBytes(getMaxUploadSize(plan))} file size limit on the ${capitalize(plan)} plan.`;
+
+  if (!isFreePlan(plan)) return message;
+  return `${message} Upgrade to Pro to upload files up to ${formatBytes(MAX_UPLOAD_SIZE)}.`;
+};

--- a/apps/web/src/openapi/v1/uploads/create-batch-upload.ts
+++ b/apps/web/src/openapi/v1/uploads/create-batch-upload.ts
@@ -11,7 +11,7 @@ export const createBatchUpload: ZodOpenApiOperationObject = {
   "x-speakeasy-name-override": "createBatch",
   summary: "Create presigned URLs for batch file upload",
   description:
-    "Generate presigned URLs for uploading multiple files to the specified namespace.",
+    "Generate presigned URLs for uploading multiple files to the specified namespace. Files are limited to 5 MB on the Free plan and 200 MB on paid plans.",
   parameters: [namespaceIdPathSchema],
   requestBody: {
     required: true,

--- a/apps/web/src/openapi/v1/uploads/create-upload.ts
+++ b/apps/web/src/openapi/v1/uploads/create-upload.ts
@@ -10,7 +10,7 @@ export const createUpload: ZodOpenApiOperationObject = {
   "x-speakeasy-name-override": "create",
   summary: "Create presigned URL for file upload",
   description:
-    "Generate a presigned URL for uploading a single file to the specified namespace.",
+    "Generate a presigned URL for uploading a single file to the specified namespace. Files are limited to 5 MB on the Free plan and 200 MB on paid plans.",
   parameters: [namespaceIdPathSchema],
   requestBody: {
     required: true,

--- a/apps/web/src/schemas/api/upload.ts
+++ b/apps/web/src/schemas/api/upload.ts
@@ -4,7 +4,11 @@ import {
 } from "@/services/uploads";
 import { z } from "zod/v4";
 
-import { MAX_UPLOAD_SIZE } from "@agentset/storage/constants";
+import {
+  FREE_PLAN_MAX_UPLOAD_SIZE,
+  MAX_UPLOAD_SIZE,
+} from "@agentset/storage/constants";
+import { formatBytes } from "@agentset/utils";
 
 export const uploadFileSchema = z
   .object({
@@ -32,7 +36,7 @@ export const uploadFileSchema = z
     fileSize: z
       .number()
       .meta({
-        description: "File size in bytes",
+        description: `File size in bytes. The maximum is ${formatBytes(MAX_UPLOAD_SIZE)} (${formatBytes(FREE_PLAN_MAX_UPLOAD_SIZE)} on the Free plan).`,
         examples: [1024],
       })
       .min(1)

--- a/apps/web/src/server/api/routers/uploads.ts
+++ b/apps/web/src/server/api/routers/uploads.ts
@@ -23,8 +23,21 @@ export const uploadsRouter = createTRPCRouter({
         });
       }
 
+      const organization = await ctx.db.organization.findUnique({
+        where: { id: ns.organizationId },
+        select: { plan: true },
+      });
+
+      if (!organization) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Organization not found",
+        });
+      }
+
       const result = await createUpload({
         namespaceId: ns.id,
+        plan: organization.plan,
         file: {
           fileName: input.fileName,
           contentType: input.contentType,
@@ -34,7 +47,10 @@ export const uploadsRouter = createTRPCRouter({
 
       if (!result.success) {
         throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
+          code:
+            result.code === "file_too_large"
+              ? "FORBIDDEN"
+              : "INTERNAL_SERVER_ERROR",
           message: result.error,
         });
       }
@@ -57,14 +73,30 @@ export const uploadsRouter = createTRPCRouter({
         });
       }
 
+      const organization = await ctx.db.organization.findUnique({
+        where: { id: ns.organizationId },
+        select: { plan: true },
+      });
+
+      if (!organization) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Organization not found",
+        });
+      }
+
       const result = await createBatchUpload({
         namespaceId: ns.id,
+        plan: organization.plan,
         files: input.files,
       });
 
       if (!result.success) {
         throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
+          code:
+            result.code === "file_too_large"
+              ? "FORBIDDEN"
+              : "INTERNAL_SERVER_ERROR",
           message: result.error,
         });
       }

--- a/apps/web/src/services/ingest-jobs/create.ts
+++ b/apps/web/src/services/ingest-jobs/create.ts
@@ -89,7 +89,9 @@ export const createIngestJob = async ({
         ...commonPayload,
       };
     } else if (data.payload.type === "MANAGED_FILE") {
-      const exists = await checkFileExists(data.payload.key);
+      const exists =
+        validateNamespaceFileKey(namespaceId, data.payload.key) &&
+        (await checkFileExists(data.payload.key));
       if (!exists) {
         throw new Error("FILE_NOT_FOUND");
       }

--- a/apps/web/src/services/uploads.ts
+++ b/apps/web/src/services/uploads.ts
@@ -4,7 +4,7 @@ import {
   SUPPORTED_MIME_TYPES,
   SUPPORTED_MIME_TYPES_PREFIXES,
 } from "@/lib/file-types";
-import { getMaxUploadSize, uploadSizeLimitMessage } from "@/lib/upload-limits";
+import { getMaxUploadSize, uploadSizeLimitError } from "@/lib/upload-limits";
 import { batchUploadSchema, uploadFileSchema } from "@/schemas/api/upload";
 import { z } from "zod/v4";
 
@@ -50,7 +50,7 @@ export const createUpload = async ({
     return {
       success: false as const,
       code: "file_too_large" as const,
-      error: uploadSizeLimitMessage(plan, [file.fileName]),
+      error: uploadSizeLimitError(plan, [file.fileName]),
     };
   }
 
@@ -94,7 +94,7 @@ export const createBatchUpload = async ({
     return {
       success: false as const,
       code: "file_too_large" as const,
-      error: uploadSizeLimitMessage(
+      error: uploadSizeLimitError(
         plan,
         oversizedFiles.map((file) => file.fileName),
       ),

--- a/apps/web/src/services/uploads.ts
+++ b/apps/web/src/services/uploads.ts
@@ -4,6 +4,7 @@ import {
   SUPPORTED_MIME_TYPES,
   SUPPORTED_MIME_TYPES_PREFIXES,
 } from "@/lib/file-types";
+import { getMaxUploadSize, uploadSizeLimitMessage } from "@/lib/upload-limits";
 import { batchUploadSchema, uploadFileSchema } from "@/schemas/api/upload";
 import { z } from "zod/v4";
 
@@ -39,10 +40,20 @@ export const validateNamespaceFileKey = (namespaceId: string, key: string) => {
 export const createUpload = async ({
   namespaceId,
   file,
+  plan,
 }: {
   file: z.infer<typeof uploadFileSchema>;
   namespaceId: string;
+  plan: string;
 }) => {
+  if (file.fileSize > getMaxUploadSize(plan)) {
+    return {
+      success: false as const,
+      code: "file_too_large" as const,
+      error: uploadSizeLimitMessage(plan, [file.fileName]),
+    };
+  }
+
   const key = generateStorageKey(namespaceId, file.fileName);
   const urlResult = await tryCatch(
     presignUploadUrl({
@@ -55,6 +66,7 @@ export const createUpload = async ({
   if (urlResult.error) {
     return {
       success: false as const,
+      code: "presign_failed" as const,
       error: "Failed to generate presigned URL",
     };
   }
@@ -71,7 +83,24 @@ export const createUpload = async ({
 export const createBatchUpload = async ({
   namespaceId,
   files,
-}: z.infer<typeof batchUploadSchema> & { namespaceId: string }) => {
+  plan,
+}: z.infer<typeof batchUploadSchema> & {
+  namespaceId: string;
+  plan: string;
+}) => {
+  const maxUploadSize = getMaxUploadSize(plan);
+  const oversizedFiles = files.filter((file) => file.fileSize > maxUploadSize);
+  if (oversizedFiles.length > 0) {
+    return {
+      success: false as const,
+      code: "file_too_large" as const,
+      error: uploadSizeLimitMessage(
+        plan,
+        oversizedFiles.map((file) => file.fileName),
+      ),
+    };
+  }
+
   const preparedFiles = files.map((file) => ({
     ...file,
     key: generateStorageKey(namespaceId, file.fileName),
@@ -97,6 +126,7 @@ export const createBatchUpload = async ({
   if (failedResults.length > 0) {
     return {
       success: false as const,
+      code: "presign_failed" as const,
       error: "Failed to generate presigned URLs",
     };
   }

--- a/docs/data-ingestion/file-uploads.mdx
+++ b/docs/data-ingestion/file-uploads.mdx
@@ -9,21 +9,21 @@ Upload documents to Agentset for processing. You can either provide a URL to a p
 
 Agentset supports the following file formats for ingestion.
 
-| Type | Extensions |
-| :--- | :--- |
-| PDF | `.pdf` |
-| Spreadsheet | `.csv`, `.xls`, `.xlsx`, `.ods` |
-| Word | `.doc`, `.docx`, `.odt` |
-| Presentation | `.ppt`, `.pptx`, `.odp` |
-| HTML | `.html`, `.htm` |
-| EPUB | `.epub` |
-| Image | `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`, `.tiff` |
-| Outlook | `.msg` |
-| Plain text | `.txt` |
-| Markdown | `.md` |
-| JSON | `.json`, `.jsonl` |
-| XML | `.xml` |
-| RSS | `.rss`, `.atom` |
+| Type         | Extensions                                        |
+| :----------- | :------------------------------------------------ |
+| PDF          | `.pdf`                                            |
+| Spreadsheet  | `.csv`, `.xls`, `.xlsx`, `.ods`                   |
+| Word         | `.doc`, `.docx`, `.odt`                           |
+| Presentation | `.ppt`, `.pptx`, `.odp`                           |
+| HTML         | `.html`, `.htm`                                   |
+| EPUB         | `.epub`                                           |
+| Image        | `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`, `.tiff` |
+| Outlook      | `.msg`                                            |
+| Plain text   | `.txt`                                            |
+| Markdown     | `.md`                                             |
+| JSON         | `.json`, `.jsonl`                                 |
+| XML          | `.xml`                                            |
+| RSS          | `.rss`, `.atom`                                   |
 
 ## Upload from URL
 
@@ -34,20 +34,21 @@ Provide a URL to a file and Agentset will fetch and process it.
 import { Agentset } from "agentset";
 
 const agentset = new Agentset({
-  apiKey: process.env.AGENTSET_API_KEY,
+apiKey: process.env.AGENTSET_API_KEY,
 });
 
 const ns = agentset.namespace("YOUR_NAMESPACE_ID");
 
 const job = await ns.ingestion.create({
-  payload: {
-    type: "FILE",
-    fileUrl: "https://example.com/document.pdf",
-  },
+payload: {
+type: "FILE",
+fileUrl: "https://example.com/document.pdf",
+},
 });
 
 console.log(`Upload started: ${job.id}`);
-```
+
+````
 
 ```python Python
 import os
@@ -66,7 +67,8 @@ job = client.ingest_jobs.create(
 )
 
 print(f"Upload started: {job.data.id}")
-```
+````
+
 </CodeGroup>
 
 ## Direct upload
@@ -78,21 +80,22 @@ Upload files directly from your application using presigned URLs. This is useful
 import fs from "fs";
 
 const upload = await ns.uploads.upload({
-  file: fs.createReadStream("./document.pdf"),
-  contentType: "application/pdf",
+file: fs.createReadStream("./document.pdf"),
+contentType: "application/pdf",
 });
 
 // Create an ingest job for the uploaded file
 const job = await ns.ingestion.create({
-  payload: {
-    type: "MANAGED_FILE",
-    key: upload.key,
-    fileName: "document.pdf",
-  },
+payload: {
+type: "MANAGED_FILE",
+key: upload.key,
+fileName: "document.pdf",
+},
 });
 
 console.log(`Upload started: ${job.id}`);
-```
+
+````
 
 ```python Python
 import os
@@ -125,7 +128,8 @@ job = client.ingest_jobs.create(
 )
 
 print(f"Upload started: {job.data.id}")
-```
+````
+
 </CodeGroup>
 
 ## With metadata
@@ -166,14 +170,16 @@ job = client.ingest_jobs.create(
     },
 )
 ```
+
 </CodeGroup>
 
 ## File size limit
 
-The maximum file size is 200 MB.
+The maximum file size is 5 MB on the Free plan and 200 MB on paid plans.
 
 <Info>
-  File uploads are processed asynchronously. Learn how to [check upload status](/data-ingestion/upload-status).
+  File uploads are processed asynchronously. Learn how to [check upload
+  status](/data-ingestion/upload-status).
 </Info>
 
 ## Next steps

--- a/packages/storage/src/constants.ts
+++ b/packages/storage/src/constants.ts
@@ -1,1 +1,2 @@
 export const MAX_UPLOAD_SIZE = 200 * 1024 * 1024; // 200MB
+export const FREE_PLAN_MAX_UPLOAD_SIZE = 5 * 1024 * 1024; // 5MB

--- a/packages/ui/src/components/file-uploader.tsx
+++ b/packages/ui/src/components/file-uploader.tsx
@@ -90,6 +90,14 @@ interface FileUploaderProps extends React.HTMLAttributes<HTMLDivElement> {
    * @example disabled
    */
   disabled?: boolean;
+
+  /**
+   * Function to be called with the rejected files of a drop, replacing the default toasts.
+   * @type (rejections: FileRejection[]) => void
+   * @default undefined
+   * @example onFilesReject={(rejections) => toast.error(`${rejections.length} files are too large`)}
+   */
+  onFilesReject?: (rejections: FileRejection[]) => void;
 }
 
 export function FileUploader(props: FileUploaderProps) {
@@ -105,6 +113,7 @@ export function FileUploader(props: FileUploaderProps) {
     maxFileCount = 1,
     multiple = false,
     disabled = false,
+    onFilesReject,
     className,
     ...dropzoneProps
   } = props;
@@ -137,9 +146,13 @@ export function FileUploader(props: FileUploaderProps) {
       setFiles(updatedFiles);
 
       if (rejectedFiles.length > 0) {
-        rejectedFiles.forEach(({ file }) => {
-          toast.error(`File ${file.name} was rejected`);
-        });
+        if (onFilesReject) {
+          onFilesReject(rejectedFiles);
+        } else {
+          rejectedFiles.forEach(({ file }) => {
+            toast.error(`File ${file.name} was rejected`);
+          });
+        }
       }
 
       if (
@@ -161,7 +174,7 @@ export function FileUploader(props: FileUploaderProps) {
       }
     },
 
-    [files, maxFileCount, multiple, onUpload, setFiles],
+    [files, maxFileCount, multiple, onUpload, onFilesReject, setFiles],
   );
 
   function onRemove(index: number) {

--- a/packages/ui/src/components/file-uploader.tsx
+++ b/packages/ui/src/components/file-uploader.tsx
@@ -98,6 +98,14 @@ interface FileUploaderProps extends React.HTMLAttributes<HTMLDivElement> {
    * @example onFilesReject={(rejections) => toast.error(`${rejections.length} files are too large`)}
    */
   onFilesReject?: (rejections: FileRejection[]) => void;
+
+  /**
+   * Content rendered between the dropzone and the file list (e.g. validation errors).
+   * @type React.ReactNode
+   * @default undefined
+   * @example message={<p>File is too large</p>}
+   */
+  message?: React.ReactNode;
 }
 
 export function FileUploader(props: FileUploaderProps) {
@@ -114,6 +122,7 @@ export function FileUploader(props: FileUploaderProps) {
     multiple = false,
     disabled = false,
     onFilesReject,
+    message,
     className,
     ...dropzoneProps
   } = props;
@@ -259,6 +268,7 @@ export function FileUploader(props: FileUploaderProps) {
           </div>
         )}
       </Dropzone>
+      {message}
       {files?.length ? (
         <ScrollArea className="h-fit w-full px-3">
           <div className="flex max-h-48 flex-col gap-4">


### PR DESCRIPTION
## Summary

Free-plan organizations are now limited to **5 MB per uploaded file**. Paid plans keep the existing 200 MB limit. Free users who try to upload a larger file get a friendly inline error asking them to upgrade to Pro — in the dashboard and via the public API.

## Screenshots

**Free plan — ingest dialog.** Dropzone reads "up to 5 MB each":

<img src="https://raw.githubusercontent.com/agentset-ai/agentset/f73f7d20db4f8ede2b71578d06442dd0d29074cd/1-free-ingest-modal.png" width="800" />

**Free plan — oversized file rejected.** A 2 MB file is accepted while a 6 MB file shows an inline error between the dropzone and the selected files, with an "Upgrade to Pro" link to the plans page. Multiple oversized files aggregate into one message ("2 files exceed …"), and the error clears when the selection changes:

<img src="https://raw.githubusercontent.com/agentset-ai/agentset/f73f7d20db4f8ede2b71578d06442dd0d29074cd/2-free-inline-error.png" width="800" />

**Pro plan — unchanged.** Still "up to 200 MB each":

<img src="https://raw.githubusercontent.com/agentset-ai/agentset/f73f7d20db4f8ede2b71578d06442dd0d29074cd/3-pro-ingest-modal.png" width="800" />

**Where the Upgrade to Pro link lands:**

<img src="https://raw.githubusercontent.com/agentset-ai/agentset/f73f7d20db4f8ede2b71578d06442dd0d29074cd/4-upgrade-page.png" width="800" />

## How it works

- **Server-side (the real enforcement):** `createUpload` / `createBatchUpload` in `services/uploads.ts` now require the organization's `plan` and reject oversized files with a typed `file_too_large` result. Both tRPC procedures and both public v1 upload routes pass it — the parameter is required, so no entry point can skip the check. tRPC surfaces it as 403 `FORBIDDEN`; the public API returns `rate_limit_exceeded`, the same convention as the existing pages-limit check (and the code documented in the OpenAPI 429 schema). Because presigned PUT URLs sign `content-length`, the declared `fileSize` is enforced by the storage provider at upload time — declaring a small size and PUTing a bigger file fails the signature.
- **Client-side UX:** the ingest dropzone uses a plan-aware `maxSize` via the new `getMaxUploadSize(plan)` helper (`apps/web/src/lib/upload-limits.ts`). Rejected oversized files render a single aggregated error above the selected-files list (via a new `message` slot on `FileUploader`), with an "Upgrade to Pro" link for free orgs; the error clears when the selection changes. `FileUploader` gains optional `onFilesReject` and `message` props; behavior is unchanged for consumers that don't pass it. Presign errors reaching the dashboard now surface the server's message instead of a generic "Failed to upload file!".
- **Related fix found while testing:** single `MANAGED_FILE` ingest jobs skipped `validateNamespaceFileKey` (the batch path already had it), so a key from another namespace could be ingested by anyone who knew it — which would also have been the easiest way around this limit. The singular path now mirrors the batch validation.
- **Docs:** OpenAPI operation descriptions, the `fileSize` schema description, and `docs/data-ingestion/file-uploads.mdx` updated to mention the per-plan limits.

## Behavior notes

- Pro/enterprise uploads are byte-for-byte unchanged (200 MB cap, same errors).
- Unknown/custom plan strings keep the 200 MB limit — only `free` is restricted.
- Pre-existing and intentionally untouched: external-URL ingestion (`FILE` payloads with `fileUrl`) has no size check on any plan.

## Testing

- Live-tested against a local stack: free org + 6 MB → 403 with the friendly message; free org + 2 MB and pro org + 6 MB → presigned URLs issued normally; generated URLs sign `content-length` (`X-Amz-SignedHeaders: content-length;content-type;host`).
- Browser-tested the dialog end to end: plan-aware dropzone copy, aggregated inline error for multiple oversized files, error clearing on selection change, and the Upgrade to Pro link navigating to the plans page.
- Typecheck and lint introduce no new issues (the remaining failures were baseline-verified to exist on `main`).

Screenshots are hosted on the `assets/free-plan-upload-limit` branch and are not part of this PR's diff.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a 5 MB per-file upload limit for free-plan organizations, with 200 MB kept for paid plans. The enforcement is server-side (in `createUpload` / `createBatchUpload`), surfaced to both the tRPC and public API paths, with a plan-aware client-side dropzone and friendly inline error for the dashboard.

- **Server-side enforcement**: `createUpload` / `createBatchUpload` now accept a `plan` parameter and return a typed `file_too_large` result; the tRPC router translates this to `FORBIDDEN` (403) and the public API to `rate_limit_exceeded` (429). Both code paths add an extra DB query to fetch `organization.plan` in the tRPC router (the public API handler already carries `organization` in its params).
- **Client-side UX**: A `getMaxUploadSize(plan)` helper drives the dropzone's `maxSize`, `onFilesReject` separates size rejections from other rejections, and an inline `message` prop on `FileUploader` shows the size error with an \"Upgrade to Pro\" link for free orgs. The previous catch-all \"Failed to upload file!\" in `useUploadFiles` is now replaced by the actual tRPC error message.
- **Security fix**: Single `MANAGED_FILE` ingest jobs now call `validateNamespaceFileKey` (matching the batch path), closing a gap where a key from another namespace could be submitted.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the upload limit is enforced at the service layer before any presign URL is issued, all entry points (tRPC + public API) pass the plan, and the security fix for validateNamespaceFileKey on the single-file path is correct.

The feature is implemented in depth: a plan-aware size check in the shared service layer, consistent error codes across both API surfaces, a client-side dropzone that respects the same limit, and proper propagation of server error messages to the user. The only finding is a cosmetic UX edge case where a stale error banner can reappear after toggling the source-type radio.

No files require special attention — all changed files implement their part of the feature correctly.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/services/uploads.ts | Core enforcement layer: plan-aware size check added before presign URL generation; typed file_too_large / presign_failed result codes added throughout. |
| apps/web/src/lib/upload-limits.ts | New helper module; getMaxUploadSize and uploadSizeLimitMessage/uploadSizeLimitError centralise the plan-aware limit and error strings. |
| apps/web/src/app/app.agentset.ai/(dashboard)/[slug]/[namespaceSlug]/documents/ingest-modal/files-form.tsx | Plan-aware maxSize, onFilesReject callback splitting size vs. other errors, and inline sizeError message with Upgrade to Pro link; sizeError is not reset when the user toggles the source-type tab. |
| apps/web/src/server/api/routers/uploads.ts | Both tRPC mutations now fetch organization.plan and pass it to the service; FORBIDDEN is returned for file_too_large. |
| apps/web/src/services/ingest-jobs/create.ts | Security fix: single MANAGED_FILE path now calls validateNamespaceFileKey, closing the gap that already existed in the batch path. |
| packages/ui/src/components/file-uploader.tsx | Added onFilesReject and message props; onFilesReject is included in the onDrop useCallback dep array; backward-compatible with existing consumers. |
| apps/web/src/hooks/use-upload.ts | Catch block now surfaces tRPC error messages directly instead of swallowing them with a generic fallback. |
| packages/storage/src/constants.ts | Adds FREE_PLAN_MAX_UPLOAD_SIZE = 5 MB constant alongside the existing 200 MB cap. |
| apps/web/src/schemas/api/upload.ts | Updated fileSize description to mention per-plan limits; the .max(MAX_UPLOAD_SIZE) hard cap is still correct and enforces the global ceiling. |

<sub>Reviews (3): Last reviewed commit: ["Render the upload size error above the s..."](https://github.com/agentset-ai/agentset/commit/44b743a149009aaa2af94e46b5f063c701bd437e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41311345)</sub>

<!-- /greptile_comment -->