### PR TITLE
Fix Vercel deploys: add missing pg types to the db package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -87,6 +87,7 @@
       "dependencies": {
         "@prisma/adapter-pg": "^7.4.1",
         "@prisma/client": "^7.4.1",
+        "pg": "^8.16.3",
         "zod": "catalog:",
       },
       "devDependencies": {
@@ -94,6 +95,7 @@
         "@agentset/prettier-config": "workspace:*",
         "@agentset/tsconfig": "workspace:*",
         "@agentset/validation": "workspace:*",
+        "@types/pg": "^8.20.0",
         "eslint": "catalog:",
         "prettier": "catalog:",
         "prisma": "^7.4.1",
@@ -1465,6 +1467,8 @@
     "@types/node": ["@types/node@22.19.7", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw=="],
 
     "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "22.18.4", "form-data": "4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
+
+    "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
 
     "@types/react": ["@types/react@19.2.6", "", { "dependencies": { "csstype": "3.2.3" } }, "sha512-p/jUvulfgU7oKtj6Xpk8cA2Y1xKTtICGpJYeJXz2YVO2UcvjQgeRMLDGfDeqeRW2Ta+0QNFwcc8X3GH8SxZz6w=="],
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@prisma/adapter-pg": "^7.4.1",
     "@prisma/client": "^7.4.1",
+    "pg": "^8.16.3",
     "zod": "catalog:"
   },
   "prisma": {
@@ -36,6 +37,7 @@
     "@agentset/prettier-config": "workspace:*",
     "@agentset/tsconfig": "workspace:*",
     "@agentset/validation": "workspace:*",
+    "@types/pg": "^8.20.0",
     "eslint": "catalog:",
     "prettier": "catalog:",
     "prisma": "^7.4.1",


### PR DESCRIPTION
## Summary

Every Vercel deploy (previews and production) has been failing since the Prisma v7 upgrade with:

```
@agentset/db:build: src/client.ts(3,22): error TS7016: Could not find a declaration
file for module 'pg'. '/vercel/path0/node_modules/pg/esm/index.mjs' implicitly has an 'any' type.
```

The Prisma v7 driver-adapter setup added a direct `import { Pool } from "pg"` to `packages/db/src/client.ts`, but the package declared neither `pg` nor `@types/pg`. At runtime `pg` resolved as a transitive dependency of `@prisma/adapter-pg`, but on a clean CI install there are no type declarations, so the package's `tsc` build exits 2 and takes every deploy down with it. (Local builds pass only when `@types/pg` happens to be in `node_modules` from an unrelated install.)

## Fix

- `pg` added to `dependencies` (pinned to the version already resolved transitively, `^8.16.3`) — it's imported at runtime, so it shouldn't rely on hoisting.
- `@types/pg` added to `devDependencies`.

Verified `@agentset/db` builds with a forced (uncached) turbo run. This PR's Vercel preview deploy is the end-to-end proof.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes CI/Vercel build failures introduced by the Prisma v7 upgrade by explicitly declaring `pg` and `@types/pg` as dependencies of `packages/db`, where `client.ts` directly imports `{ Pool } from "pg"`.

- `pg@^8.16.3` added to `dependencies` — required at runtime for the Prisma driver adapter, matches the version already resolved transitively.
- `@types/pg@^8.20.0` added to `devDependencies` — provides type declarations so `tsc` resolves the import on a clean install.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal dependency declaration fix with no logic changes.

Both additions are correct: `pg` belongs in `dependencies` because `client.ts` imports it at runtime, and `@types/pg` belongs in `devDependencies` as a type-only package. The pinned versions are internally consistent — `@types/pg@8.x` matches `pg@8.x` — and align with the version already resolved transitively by `@prisma/adapter-pg`.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/db/package.json | Adds `pg` to runtime dependencies and `@types/pg` to devDependencies to fix a TypeScript build error on clean CI installs. |
| bun.lock | Lockfile updated to reflect the two new explicit dependencies (`pg@8.16.3` and `@types/pg@8.20.0`) added to `packages/db`. |

<sub>Reviews (1): Last reviewed commit: ["Add missing pg and @types/pg dependencie..."](https://github.com/agentset-ai/agentset/commit/300d18ce2bc4fa11d45a55b293b227a178f4ae17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41319453)</sub>

<!-- /greptile_comment -->