### PR TITLE
Make agentic citations backwards compatible with custom system prompts

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,8 @@
     "lint:fix": "bun run lint --fix",
     "preview": "next build && next start",
     "start": "bun --env-file=../../.env run next start",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -81,7 +83,8 @@
     "postcss": "^8.4.39",
     "prettier": "catalog:",
     "tailwindcss": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "prettier": "@agentset/prettier-config"
 }

--- a/apps/web/src/app/api/(internal-api)/chat/schema.ts
+++ b/apps/web/src/app/api/(internal-api)/chat/schema.ts
@@ -1,4 +1,3 @@
-import { AGENTIC_SYSTEM_PROMPT } from "@/lib/agentic-search/prompts";
 import { baseQueryVectorStoreSchema } from "@/schemas/api/query";
 import { messagesSchema } from "@/schemas/chat";
 import { z } from "zod/v4";
@@ -32,9 +31,8 @@ export const chatSchema = baseQueryVectorStoreSchema
     systemPrompt: z
       .string()
       .optional()
-      .default(AGENTIC_SYSTEM_PROMPT)
       .describe(
-        "The system prompt to use for the chat. Defaults to the agentic search system prompt.",
+        "Custom instructions for the chat. Defaults to the agentic search system prompt; custom prompts are augmented with the platform tool and citation contract.",
       ),
     messages: messagesSchema,
     temperature: z.number().optional(),

--- a/apps/web/src/app/api/(internal-api)/hosting-chat/route.ts
+++ b/apps/web/src/app/api/(internal-api)/hosting-chat/route.ts
@@ -1,13 +1,11 @@
 import type { SearchToolConfig } from "@/lib/agentic-search/tools";
 import { agenticSearchPipeline } from "@/lib/agentic-search";
-import { AGENTIC_SYSTEM_PROMPT } from "@/lib/agentic-search/prompts";
 import { agenticTools } from "@/lib/agentic-search/tools";
 import { AgentsetApiError, exceededLimitError } from "@/lib/api/errors";
 import { withPublicApiHandler } from "@/lib/api/handler/public";
 import { hostingAuth } from "@/lib/api/hosting-auth";
 import { ratelimit } from "@/lib/api/rate-limit";
 import { parseRequestBody } from "@/lib/api/utils";
-import { DEFAULT_SYSTEM_PROMPT } from "@/lib/prompts";
 import { waitUntil } from "@vercel/functions";
 import { convertToModelMessages, pruneMessages } from "ai";
 
@@ -71,16 +69,6 @@ const getHosting = async (namespaceId: string) => {
       },
     },
   });
-};
-
-// hosting rows created before the agentic migration store the old single-shot
-// RAG prompt verbatim; those should pick up the new agentic default
-const LEGACY_DEFAULT_PROMPT = DEFAULT_SYSTEM_PROMPT.compile().trim();
-const getSystemPrompt = (storedPrompt: string | null) => {
-  if (!storedPrompt || storedPrompt.trim() === LEGACY_DEFAULT_PROMPT) {
-    return AGENTIC_SYSTEM_PROMPT;
-  }
-  return storedPrompt;
 };
 
 export const preferredRegion = "iad1"; // make this closer to the DB
@@ -182,7 +170,9 @@ export const POST = withPublicApiHandler(
 
     return agenticSearchPipeline({
       languageModel,
-      systemPrompt: getSystemPrompt(hosting.systemPrompt),
+      // stored default/null resolves to the agentic prompt; custom prompts
+      // get the platform citation contract appended inside the pipeline
+      systemPrompt: hosting.systemPrompt,
       messages,
       context: {
         vectorStore,

--- a/apps/web/src/app/app.agentset.ai/(dashboard)/[slug]/[namespaceSlug]/hosting/use-hosting-form.ts
+++ b/apps/web/src/app/app.agentset.ai/(dashboard)/[slug]/[namespaceSlug]/hosting/use-hosting-form.ts
@@ -1,7 +1,10 @@
+import type { RouterOutputs } from "@/trpc/react";
 import { useNamespace } from "@/hooks/use-namespace";
+import {
+  AGENTIC_SYSTEM_PROMPT,
+  isKnownDefaultPrompt,
+} from "@/lib/agentic-search/prompts";
 import { logEvent } from "@/lib/analytics";
-import { AGENTIC_SYSTEM_PROMPT } from "@/lib/agentic-search/prompts";
-import type { RouterOutputs} from "@/trpc/react";
 import { useTRPC } from "@/trpc/react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -98,7 +101,11 @@ export function useHostingForm(data: HostingData) {
       protected: data.protected,
       allowedEmails: data.allowedEmails,
       allowedEmailDomains: data.allowedEmailDomains,
-      systemPrompt: data.systemPrompt || AGENTIC_SYSTEM_PROMPT,
+      // default-shaped stored prompts (null, or a pinned copy of an old
+      // default) display the prompt that actually runs, not the stale snapshot
+      systemPrompt: isKnownDefaultPrompt(data.systemPrompt)
+        ? AGENTIC_SYSTEM_PROMPT
+        : data.systemPrompt!,
       exampleQuestions:
         data.exampleQuestions.length === 0 ? [""] : data.exampleQuestions,
       exampleSearchQueries:

--- a/apps/web/src/components/chat/chat-settings.store.ts
+++ b/apps/web/src/components/chat/chat-settings.store.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_SYSTEM_PROMPT } from "@/lib/prompts";
+import { isKnownDefaultPrompt } from "@/lib/agentic-search/prompts";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { useShallow } from "zustand/react/shallow";
@@ -119,11 +119,11 @@ export const useChatSettings = create<ChatSettings>()(
                   mode?: string;
                 };
 
-                // users who saved the old single-shot RAG prompt verbatim
-                // should pick up the new agentic default
-                const isLegacyDefaultPrompt =
-                  namespace.systemPrompt?.trim() ===
-                  DEFAULT_SYSTEM_PROMPT.compile().trim();
+                // users who saved an old default prompt verbatim should pick
+                // up the new agentic default
+                const isLegacyDefaultPrompt = isKnownDefaultPrompt(
+                  namespace.systemPrompt,
+                );
 
                 const topK =
                   namespace.topK === 50

--- a/apps/web/src/lib/agentic-search/index.ts
+++ b/apps/web/src/lib/agentic-search/index.ts
@@ -11,17 +11,28 @@ import {
 import type { NamespaceLanguageModel } from "@agentset/engine";
 
 import type { AgenticToolContext } from "./tools";
+import { resolveSystemPrompt } from "./prompts";
 import { agenticTools } from "./tools";
 
 export type { AgenticToolContext, SearchToolConfig } from "./tools";
-export { AGENTIC_SYSTEM_PROMPT } from "./prompts";
+export {
+  AGENTIC_SYSTEM_PROMPT,
+  isKnownDefaultPrompt,
+  resolveSystemPrompt,
+} from "./prompts";
 
 // stop after 20 steps
 const MAX_STEPS = 20;
 
 type AgenticSearchPipelineOptions = {
   languageModel: NamespaceLanguageModel;
-  systemPrompt: string;
+  /**
+   * Raw stored/user-supplied prompt; resolved via resolveSystemPrompt (pass
+   * the stored value as-is, don't pre-default it). Default-shaped prompts run
+   * the tuned agentic prompt; custom prompts get the platform tool and
+   * citation contract appended.
+   */
+  systemPrompt?: string | null;
   messages: ModelMessage[];
   context: AgenticToolContext;
   temperature?: number;
@@ -66,7 +77,7 @@ export const agenticSearchPipeline = ({
     execute: ({ writer }) => {
       const result = streamText({
         model: languageModel.model,
-        system: systemPrompt,
+        system: resolveSystemPrompt(systemPrompt),
         messages,
         tools: agenticTools,
         // expand needs an ordered range fetch, which not all stores support

--- a/apps/web/src/lib/agentic-search/prompts.ts
+++ b/apps/web/src/lib/agentic-search/prompts.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_SYSTEM_PROMPT } from "@/lib/prompts";
+
 export const AGENTIC_SYSTEM_PROMPT = `You are an AI research assistant powered by Agentset, with access to the user's knowledge base through the available search and expand tools.
 
 <tool_persistence_rules>
@@ -51,3 +53,70 @@ export const AGENTIC_SYSTEM_PROMPT = `You are an AI research assistant powered b
 
 **Search label language**
 For every \`search\` call, set \`label\` to a short description of the search intent written in the user's language. Never change \`query\`, which stays optimized for retrieval.`;
+
+const normalizePrompt = (prompt: string) =>
+  prompt.replace(/\r\n/g, "\n").trim();
+
+// FROZEN: the default prompt text before commit b5ae41e (2025-04-01). The
+// playground settings dialog could persist it verbatim to localStorage
+// between 2025-03-28 and 2025-04-01; the chat-settings v4 migration and
+// resolveSystemPrompt should treat it as a default, not a custom prompt.
+export const LEGACY_DEFAULT_PROMPT_2025_03 = `You are an AI assistant powered by Agentset, a leading RAG-as-a-service platform. Your task is to deliver accurate and cited responses to user queries by analyzing the provided search results. Since search results are not visible to users, you MUST incorporate relevant excerpts in your responses. Your answers should be high-quality, expert-level, and maintain an unbiased, professional tone. It is CRUCIAL to directly address the query. NEVER preface responses with phrases like "based on the search results". Your response must match the language of the query, regardless of the search results' language.
+
+You MUST cite the most relevant search results that address the query, omitting any irrelevant ones. Follow these STRICT citation guidelines: - cite search results by enclosing the index number (found above each summary) in brackets at the end of the relevant sentence, for example "Water freezes at 0 degrees Celsius[12]" or "Tokyo is Japan's largest city[45]" - NO SPACE between the last word and citation, ALWAYS use brackets. Only use this format for citations. NEVER add a References section. - If you cannot answer the query or identify incorrect premises, explain why. If search results are missing or inadequate, you MUST inform the user that no relevant references were found and refrain from answering.
+
+Include direct quotes from search results with proper citations when they enhance the answer or provide valuable context.`;
+
+// every prompt text the app has ever auto-written into storage (hosting rows,
+// playground localStorage). When editing AGENTIC_SYSTEM_PROMPT, append the OLD
+// text here as a literal — otherwise rows that pinned it verbatim are treated
+// as custom (citations still work via the appended contract, but they stop
+// tracking the tuned default)
+const KNOWN_DEFAULT_PROMPTS = [
+  // pre-agentic single-shot RAG default (frozen; see comment in lib/prompts.ts)
+  DEFAULT_SYSTEM_PROMPT.compile(),
+  LEGACY_DEFAULT_PROMPT_2025_03,
+  AGENTIC_SYSTEM_PROMPT,
+].map(normalizePrompt);
+
+/**
+ * True for null/empty/whitespace-only prompts and any default text the app has
+ * ever auto-persisted. These resolve to the live tuned default.
+ */
+export const isKnownDefaultPrompt = (
+  prompt: string | null | undefined,
+): boolean =>
+  !prompt?.trim() || KNOWN_DEFAULT_PROMPTS.includes(normalizePrompt(prompt));
+
+// appended to every custom system prompt. Many stored prompts derive from the
+// legacy default, which mandates bracket-number citations ("20 degrees[3]")
+// that the agentic UI can't render; this block overrides that and teaches the
+// <citation ids> contract. It intentionally overlaps AGENTIC_SYSTEM_PROMPT's
+// <grounding_and_citations> block — keep the citation format in sync when
+// editing either
+export const PLATFORM_CONTRACT_PROMPT = `<agentset_platform_rules>
+The rules in this section are enforced by the Agentset platform. They are always in effect and take precedence over any conflicting instruction above.
+
+Retrieval:
+- The user's knowledge base is only accessible through the \`search\` and \`expand\` tools. Call \`search\` before answering; call \`expand\` when a relevant chunk appears incomplete, cut off, or needs nearby context. Any instruction above that mentions "provided chunks", "search results", or "context" refers to these tool results.
+- For every \`search\` call, set \`label\` to a short description of the search intent written in the user's language. Never change \`query\`, which stays optimized for retrieval.
+
+Citations:
+- Every factual statement taken from the knowledge base must be followed immediately by <citation ids="<chunk-id1>,<chunk-id2>,..." /> using the \`id\` field of the tool results, like this: The temperature is 20 degrees <citation ids="doc_123#4" />
+- This is the ONLY citation format the application can render. It replaces any citation or reference format described above: never place chunk numbers in brackets like [0], [1], or [3], never use footnotes, and never add a separate sources/references section at the end. Bracketed numbers render as dead text for the user.
+- Multiple <citation ... /> tags may follow one statement.
+</agentset_platform_rules>`;
+
+/**
+ * Resolves a stored/user-supplied system prompt into the prompt the model runs
+ * with: default-shaped prompts get the tuned AGENTIC_SYSTEM_PROMPT verbatim;
+ * anything else keeps the customer's text and appends the platform tool and
+ * citation contract, so citations keep rendering regardless of what the custom
+ * prompt says.
+ */
+export const resolveSystemPrompt = (
+  storedPrompt: string | null | undefined,
+): string =>
+  isKnownDefaultPrompt(storedPrompt)
+    ? AGENTIC_SYSTEM_PROMPT
+    : `${storedPrompt!.trim()}\n\n${PLATFORM_CONTRACT_PROMPT}`;

--- a/apps/web/src/lib/code-examples/playground.ts
+++ b/apps/web/src/lib/code-examples/playground.ts
@@ -25,7 +25,7 @@ console.log(results);
 
 export const aiSdkExample = (apiKey?: string) => /* typescript */ `
 import { Agentset } from "agentset";
-import { DEFAULT_PROMPT, makeAgentsetTool } from "@agentset/ai-sdk";
+import { DEFAULT_SYSTEM_PROMPT, makeAgentsetTool } from "@agentset/ai-sdk";
 import { generateText } from "ai";
 
 const agentset = new Agentset({

--- a/apps/web/src/lib/prompts.ts
+++ b/apps/web/src/lib/prompts.ts
@@ -1,5 +1,8 @@
 import { prmpt } from "@/lib/prompt";
 
+// FROZEN legacy text — used only to detect pre-agentic stored prompts
+// (hosting rows + the playground localStorage migration). Never edit: the
+// detection is an exact-match against what was historically persisted.
 export const DEFAULT_SYSTEM_PROMPT = prmpt`
 You are an AI assistant powered by Agentset. Your primary task is to provide accurate, factual responses based STRICTLY on the provided search results. You must ONLY answer questions using information explicitly found in the search results - do not make assumptions or add information from outside knowledge.
 

--- a/apps/web/src/schemas/api/hosting.ts
+++ b/apps/web/src/schemas/api/hosting.ts
@@ -47,7 +47,9 @@ export const HostingSchema = z
       .string()
       .nullable()
       .default(null)
-      .describe("The system prompt used for the chat interface."),
+      .describe(
+        "Custom instructions layered on top of Agentset's retrieval and citation rules. `null` means the chat uses Agentset's default prompt.",
+      ),
     exampleQuestions: z
       .array(z.string())
       .default([])
@@ -132,7 +134,13 @@ export const updateHostingSchema = z.object({
   protected: z.boolean().optional(),
   allowedEmails: z.array(z.email().trim().toLowerCase()).optional(),
   allowedEmailDomains: z.array(z.string().trim().toLowerCase()).optional(),
-  systemPrompt: z.string().optional(),
+  systemPrompt: z
+    .string()
+    .nullable()
+    .optional()
+    .describe(
+      "Custom instructions for the chat. Agentset always appends its retrieval and citation rules, so inline citations keep working. Send null or an empty string to reset to Agentset's default prompt.",
+    ),
   exampleQuestions: z.array(z.string()).max(4).optional(),
   exampleSearchQueries: z.array(z.string()).max(4).optional(),
   welcomeMessage: z.string().optional(),

--- a/apps/web/src/services/hosting/enable.ts
+++ b/apps/web/src/services/hosting/enable.ts
@@ -1,4 +1,3 @@
-import { AGENTIC_SYSTEM_PROMPT } from "@/lib/agentic-search/prompts";
 import { AgentsetApiError } from "@/lib/api/errors";
 import { nanoid } from "nanoid";
 
@@ -45,7 +44,9 @@ export const enableHosting = async ({
       namespaceId: namespace.id,
       title: namespace.name,
       slug,
-      systemPrompt: AGENTIC_SYSTEM_PROMPT,
+      // null = track Agentset's default prompt; pinning the default text
+      // verbatim would freeze a snapshot that misses future prompt updates
+      systemPrompt: null,
     },
   });
 };

--- a/apps/web/src/services/hosting/update.ts
+++ b/apps/web/src/services/hosting/update.ts
@@ -1,4 +1,5 @@
 import { env } from "@/env";
+import { isKnownDefaultPrompt } from "@/lib/agentic-search/prompts";
 import { AgentsetApiError } from "@/lib/api/errors";
 import { updateHostingSchema } from "@/schemas/api/hosting";
 import { getCache, waitUntil } from "@vercel/functions";
@@ -79,7 +80,14 @@ export const updateHosting = async ({
         protected: input.protected,
         allowedEmails: input.allowedEmails ?? undefined,
         allowedEmailDomains: input.allowedEmailDomains ?? undefined,
-        systemPrompt: input.systemPrompt,
+        // default-shaped prompts (incl. re-saves of the prefilled default and
+        // "" via the public API) store null = track Agentset's default
+        systemPrompt:
+          input.systemPrompt === undefined
+            ? undefined
+            : isKnownDefaultPrompt(input.systemPrompt)
+              ? null
+              : input.systemPrompt,
         exampleQuestions: input.exampleQuestions,
         exampleSearchQueries: input.exampleSearchQueries,
         welcomeMessage: input.welcomeMessage,

--- a/apps/web/test/resolve-system-prompt.test.ts
+++ b/apps/web/test/resolve-system-prompt.test.ts
@@ -1,0 +1,107 @@
+import { createHash } from "node:crypto";
+import {
+  AGENTIC_SYSTEM_PROMPT,
+  isKnownDefaultPrompt,
+  LEGACY_DEFAULT_PROMPT_2025_03,
+  PLATFORM_CONTRACT_PROMPT,
+  resolveSystemPrompt,
+} from "@/lib/agentic-search/prompts";
+import { DEFAULT_SYSTEM_PROMPT } from "@/lib/prompts";
+import { describe, expect, it } from "vitest";
+
+const LEGACY_DEFAULT = DEFAULT_SYSTEM_PROMPT.compile();
+
+describe("resolveSystemPrompt", () => {
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["empty string", ""],
+    ["whitespace-only", "   \n\t"],
+    ["legacy default verbatim", LEGACY_DEFAULT],
+    [
+      "legacy default with CRLF line endings",
+      LEGACY_DEFAULT.replace(/\n/g, "\r\n"),
+    ],
+    ["legacy default with surrounding whitespace", `\n  ${LEGACY_DEFAULT}\n\n`],
+    // pre-b5ae41e compile() didn't trim, so stored copies carry newlines
+    ["2025-03 default variant", `\n${LEGACY_DEFAULT_PROMPT_2025_03}\n`],
+    ["agentic default verbatim", AGENTIC_SYSTEM_PROMPT],
+    [
+      "agentic default with surrounding whitespace",
+      `${AGENTIC_SYSTEM_PROMPT}\n`,
+    ],
+  ])(
+    "resolves %s to the tuned agentic prompt, identically",
+    (_label, stored) => {
+      // identity, not just equality: the tuned default must ship byte-identical
+      expect(resolveSystemPrompt(stored)).toBe(AGENTIC_SYSTEM_PROMPT);
+    },
+  );
+
+  it.each([
+    // the production-incident class: a prompt derived from the old default,
+    // still mandating bracket-number [n] citations
+    [
+      "legacy default with one edit",
+      `${LEGACY_DEFAULT}\nAlways answer in Arabic.`,
+    ],
+    [
+      "fully custom persona",
+      "You are a helpful pirate. Answer in pirate speak.",
+    ],
+  ])("appends the platform contract to %s", (_label, stored) => {
+    const resolved = resolveSystemPrompt(stored);
+    expect(resolved.startsWith(stored.trim())).toBe(true);
+    expect(resolved.endsWith(PLATFORM_CONTRACT_PROMPT)).toBe(true);
+  });
+});
+
+describe("isKnownDefaultPrompt", () => {
+  it("accepts every default the app has ever auto-persisted", () => {
+    expect(isKnownDefaultPrompt(null)).toBe(true);
+    expect(isKnownDefaultPrompt(undefined)).toBe(true);
+    expect(isKnownDefaultPrompt("")).toBe(true);
+    expect(isKnownDefaultPrompt("  \n")).toBe(true);
+    expect(isKnownDefaultPrompt(LEGACY_DEFAULT)).toBe(true);
+    expect(isKnownDefaultPrompt(AGENTIC_SYSTEM_PROMPT)).toBe(true);
+  });
+
+  it("treats any edit as custom", () => {
+    expect(isKnownDefaultPrompt(`${LEGACY_DEFAULT}.`)).toBe(false);
+    expect(isKnownDefaultPrompt("You are a helpful assistant.")).toBe(false);
+  });
+});
+
+describe("PLATFORM_CONTRACT_PROMPT", () => {
+  it("teaches the only tag shape the renderer accepts", () => {
+    // rehype-sanitize only admits lowercase <citation> with attribute `ids`
+    expect(PLATFORM_CONTRACT_PROMPT).toContain('<citation ids="');
+    expect(PLATFORM_CONTRACT_PROMPT).not.toContain("<Citation");
+    expect(PLATFORM_CONTRACT_PROMPT).not.toMatch(/<citation id=/);
+  });
+
+  it("stays in sync with AGENTIC_SYSTEM_PROMPT on the shared contract", () => {
+    // both prompts must teach the same citation tag; drift ships two
+    // divergent model contracts and breaks exactly the custom-prompt users
+    const citationFormat = '<citation ids="<chunk-id1>,<chunk-id2>,..." />';
+    expect(AGENTIC_SYSTEM_PROMPT).toContain(citationFormat);
+    expect(PLATFORM_CONTRACT_PROMPT).toContain(citationFormat);
+
+    const labelRule =
+      "set `label` to a short description of the search intent written in the user's language. Never change `query`";
+    expect(AGENTIC_SYSTEM_PROMPT).toContain(labelRule);
+    expect(PLATFORM_CONTRACT_PROMPT).toContain(labelRule);
+  });
+});
+
+describe("DEFAULT_SYSTEM_PROMPT (frozen legacy text)", () => {
+  it("has not been edited", () => {
+    // this text is an exact-match detector for prompts persisted before the
+    // agentic migration — editing it silently breaks default detection for
+    // every pre-migration hosting row. See the comment in lib/prompts.ts.
+    const hash = createHash("sha256").update(LEGACY_DEFAULT).digest("hex");
+    expect(hash).toBe(
+      "d5990b7a07519eff3588225de1d9a4c5bc7895a6050f0c102c0740a7de9ab38d",
+    );
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,14 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+  },
+});

--- a/bun.lock
+++ b/bun.lock
@@ -80,6 +80,7 @@
         "prettier": "catalog:",
         "tailwindcss": "catalog:",
         "typescript": "catalog:",
+        "vitest": "catalog:",
       },
     },
     "packages/db": {

--- a/docs/production/hosting-ui.mdx
+++ b/docs/production/hosting-ui.mdx
@@ -58,10 +58,16 @@ Configure the appearance and behavior of your hosted chat interface from the das
 | **Reranker Model** | Model used to rerank retrieved documents |
 | **Top K** | Number of documents to retrieve from the vector store (1-100) |
 | **Rerank Limit** | Number of documents to keep after reranking (1-100) |
-| **System Prompt** | Instructions that define how the assistant behaves |
+| **System Prompt** | Instructions that define the assistant's persona and behavior |
 | **Welcome Message** | Initial message shown to users when they open the chat |
 | **Citation Metadata Path** | Metadata field to display as the citation label instead of chunk IDs (e.g., `title` or `source.filename` for nested fields) |
 | **Example Questions** | Starter questions shown to users to help them begin a conversation |
+
+<Note>
+  A custom system prompt controls persona and behavior. Agentset always
+  appends its retrieval and citation rules, so inline citation pills keep
+  working — don't add citation-format instructions to a custom prompt.
+</Note>
 
 ### Search settings
 

--- a/docs/search-and-retrieval/citations.mdx
+++ b/docs/search-and-retrieval/citations.mdx
@@ -5,9 +5,17 @@ description: "Include source citations in your RAG responses"
 
 Add source citations to your RAG responses so users can verify information and explore the original documents. Citations link each statement in the generated response back to the specific chunk it came from.
 
-## Number your context chunks
+<Note>
+  In the [hosted chat](/production/hosting-ui) and the
+  [playground](/search-and-retrieval/playground), citations are automatic.
+  Agentset always applies its citation rules on top of your system prompt, so
+  customize the prompt freely — don't add citation-format instructions to it.
+  This page is for building citations into your own app with the search API.
+</Note>
 
-Include a number with each chunk in your context so the model can reference them.
+## Return chunk IDs with your context
+
+Include each chunk's `id` in the context you pass to the model. IDs stay stable no matter how many searches produced the context, which makes them more reliable than position-based numbering.
 
 <CodeGroup>
 ```typescript TypeScript
@@ -21,13 +29,14 @@ const ns = agentset.namespace("YOUR_NAMESPACE_ID");
 
 const results = await ns.search("What is multi-head attention?");
 
-// Format chunks with numbers for citation
+// Keep the id with each chunk so the model can cite it
 const context = results
-  .map((r, i) => `[${i + 1}] ${r.text}`)
+  .map((r) => JSON.stringify({ id: r.id, text: r.text }))
   .join("\n\n");
 ```
 
 ```python Python
+import json
 import os
 from agentset import Agentset
 
@@ -38,22 +47,16 @@ client = Agentset(
 
 results = client.search.execute(query="What is multi-head attention?")
 
-# Format chunks with numbers for citation
-context = "\n\n".join([f"[{i + 1}] {r.text}" for i, r in enumerate(results.data)])
+# Keep the id with each chunk so the model can cite it
+context = "\n\n".join(
+    [json.dumps({"id": r.id, "text": r.text}) for r in results.data]
+)
 ```
 </CodeGroup>
 
-This produces context like:
-
-```
-[1] Multi-head attention allows the model to jointly attend to information...
-
-[2] The Transformer uses multi-head attention in three different ways...
-```
-
 ## Instruct the model to cite sources
 
-Use a system prompt that tells the model to include citation numbers in its response.
+Use a system prompt that tells the model to cite by chunk ID.
 
 ```typescript
 import { generateText } from "ai";
@@ -64,9 +67,8 @@ const systemPrompt = `You are an AI assistant. Answer questions based ONLY on th
 Guidelines:
 1. If the context does not contain information to answer the query, state clearly: "I cannot answer this question based on the available information."
 2. Only use information directly stated in the context—do not infer or add external knowledge.
-3. Citations are mandatory for every factual statement. Place the chunk number in brackets immediately after the statement with no space, like this: "The temperature is 20 degrees[3]"
-4. When helpful, include relevant quotes from the context with citations.
-5. Do not preface responses with "based on the context"—simply provide the cited answer.
+3. Citations are mandatory for every factual statement. Place the chunk id in brackets immediately after the statement, like this: "The temperature is 20 degrees[doc_123#4]"
+4. Only cite ids that appear in the context.
 
 Context:
 ${context}`;
@@ -82,40 +84,43 @@ console.log(text);
 
 The model will respond with inline citations:
 
-```
+```text
 Multi-head attention allows the model to jointly attend to information
-from different representation subspaces[1]. The Transformer uses this
-mechanism in three ways: encoder-decoder attention, encoder self-attention,
-and decoder self-attention[2].
+from different representation subspaces[doc_042#1]. The Transformer uses
+this mechanism in three ways: encoder-decoder attention, encoder
+self-attention, and decoder self-attention[doc_042#7].
 ```
 
 ## Render citations in your UI
 
-Parse the bracket notation and render citations as clickable elements. Use a regex to find citation patterns and replace them with interactive components.
+Parse the bracket notation, look each ID up in your search results, and render citations as clickable elements. Leave unknown IDs as plain text.
 
 ```tsx
-const CITATION_REGEX = /\[(\d+)\]/g;
+const CITATION_REGEX = /\[([^\[\]\s]+)\]/g;
 
 function renderWithCitations(text: string, sources: SearchResult[]) {
+  const sourcesById = new Map(sources.map((s) => [s.id, s]));
   const parts = [];
   let lastIndex = 0;
   let match;
 
   while ((match = CITATION_REGEX.exec(text)) !== null) {
+    const source = sourcesById.get(match[1]);
+    if (!source) continue; // not a citation, leave it as text
+
     // Add text before the citation
     if (match.index > lastIndex) {
       parts.push(text.slice(lastIndex, match.index));
     }
 
     // Add clickable citation
-    const num = parseInt(match[1], 10);
     parts.push(
       <button
         key={match.index}
-        onClick={() => scrollToSource(sources[num - 1])}
+        onClick={() => scrollToSource(source)}
         className="text-blue-500 hover:underline"
       >
-        [{num}]
+        [{source.id}]
       </button>
     );
 
@@ -130,6 +135,13 @@ function renderWithCitations(text: string, sources: SearchResult[]) {
   return parts;
 }
 ```
+
+<Tip>
+  If you prefer numbered pills like `[1]` in your UI, keep IDs in the model
+  contract and map each cited ID to a display number at render time. Asking the
+  model to cite by list position instead breaks down once context comes from
+  multiple searches or gets deduplicated.
+</Tip>
 
 ## Next steps
 

--- a/docs/search-and-retrieval/playground.mdx
+++ b/docs/search-and-retrieval/playground.mdx
@@ -37,7 +37,7 @@ Open the parameters dialog to tune retrieval and generation:
 | :--- | :--- |
 | **Top K** | Number of chunks fetched per semantic search, before reranking (default 30) |
 | **Rerank Limit** | Number of chunks the model sees per search (default 10) |
-| **System Prompt** | Instructions for the assistant. Defaults to a prompt tuned for agentic search |
+| **System Prompt** | Persona and behavior instructions. Defaults to a prompt tuned for agentic search; Agentset always appends its retrieval and citation rules, so citations keep working with a custom prompt |
 | **Re-ranker** | Model used to rerank results in Accurate mode |
 | **Temperature** | Sampling temperature. Has no effect on reasoning models like GPT-5.5 |
 


### PR DESCRIPTION
## Why

#135 was instantly rolled back on Vercel: **customers with custom system prompts (playground or hosting) lost citations.**

Root cause — an asymmetry between the two pipelines:

- **Pre-#135**, the citation *instruction* lived in the customizable system prompt, but the pipeline injected numbered chunks into every message. Both prompt textareas prefill the default, so most "custom" prompts are the old default plus an edit — they kept the `[n]` mandate, and the old `remark-citations` renderer lit the numbers up.
- **Post-#135**, the `<citation ids>` contract lives *only* in `AGENTIC_SYSTEM_PROMPT`, and a custom prompt replaces it wholesale (the hosting route only remapped prompts *exactly* equal to the old default; `/api/chat` did no remapping at all). Tool descriptions never mention citations. So the model either follows the stale `[n]` clause — rendering as dead bracket text (the production screenshot, e.g. `[0]`) — or doesn't cite at all.

## What

**Compose, don't detect.** A stored system prompt is a persona layer; the pipeline contract is platform-owned and resolved at one choke point (`resolveSystemPrompt`, called inside `agenticSearchPipeline` so both routes and any future surface inherit it):

- **Default-shaped prompts** (`null`/empty/whitespace, or any default text the app ever auto-persisted — the pre-agentic RAG default, its pre-April-2025 variant, and the current agentic prompt) resolve **byte-identical** to the tuned `AGENTIC_SYSTEM_PROMPT`.
- **Anything else** runs the customer's text verbatim, with `PLATFORM_CONTRACT_PROMPT` appended: tool usage, the `label` language rule, and the `<citation ids>` format with an explicit precedence claim, a prohibition of bracket-number citations, and a colliding example that overwrites the legacy clause's pattern.

Equality detection is now a quality optimization, never load-bearing: a missed match degrades to custom-plus-contract, which still cites — the opposite failure mode of #135.

Supporting changes:

- **Write-path hygiene**: `enableHosting` stores `null` instead of pinning the default text (which would have reproduced this incident class at the next prompt edit); `updateHosting` normalizes default-shaped input to `null`, so untouched saves heal pinned rows and `""`/`null` via the public PATCH resets to default. `updateHostingSchema.systemPrompt` is now nullable so GET→PATCH round-trips of `systemPrompt: null` validate.
- The hosting form shows the prompt that actually runs (legacy-default rows used to display the old numeric-citation prompt that runtime never used — editing one character of it silently created a broken custom prompt).
- `/api/chat` drops the server-side zod default; the chat-settings v4 migration reuses `isKnownDefaultPrompt` (adds CRLF/whitespace tolerance and the 2025-03 variant).
- **Tests**: vitest added to apps/web (mirrors packages/engine); a table test encodes the compat matrix, pins the frozen legacy prompt via hash, and asserts the citation-tag/label rules stay in sync between the two prompts.
- **Docs**: `citations.mdx` no longer teaches numeric-bracket citation prompts (it manufactured exactly the broken prompt class); hosted/playground pages now say citations are automatic and prompts are a persona layer; hosting OpenAPI descriptions document `null` = default. Drive-by: the playground AI SDK sample imports `DEFAULT_SYSTEM_PROMPT` (the only prompt export any published `@agentset/ai-sdk` has).

## Compat matrix

| Stored prompt | Result |
|---|---|
| Old default verbatim (all pre-#135 rows) | tuned agentic prompt, byte-identical; heals to `null` on next save |
| **Custom derived from old default (the incident)** | persona verbatim + contract → `<citation ids>` render, zero action needed |
| Fully custom, no citation clause | persona + contract → gains citations (pre-#135 guaranteed none) |
| New default pinned verbatim (post-#135 enables/saves) | tuned agentic prompt; un-pinned to `null` on next save |
| `null` / `""` / whitespace-only | tuned agentic prompt |
| Future default edits, rows pinned to superseded text | append old text to `KNOWN_DEFAULT_PROMPTS`; if forgotten, citations still work |

## Verification

- 17-case vitest table over `resolveSystemPrompt`/`isKnownDefaultPrompt` (identity for every default shape incl. CRLF/whitespace; composition for the incident class).
- Live end-to-end against the patched `/api/hosting-chat` (local DB + Turbopuffer + Azure): **incident class** (old default + edit, `[n]` mandate) → 2 resolvable `<citation ids>` tags, zero numeric citations, custom instructions honored; **fully custom pirate persona** → persona preserved, search ran, citation resolves; **null row** → default path intact.
- Typecheck/lint clean on touched files (only the two known pre-existing repo errors remain).

Adversarially reviewed (11 verified findings); accepted trade-offs: whitespace-only stored prompts now resolve to the default (previously they ran a blank prompt with no working citations either), and `enableHosting` returning `systemPrompt: null` is the documented "track the default" contract.

Closes the rollback blocker on #135.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a production rollback (#135) where customers with custom system prompts lost inline citations. The root cause was that the previous agentic citation contract lived only in the default `AGENTIC_SYSTEM_PROMPT`, so any custom prompt bypassed it entirely.

The fix introduces a \"compose, don't detect\" approach:

- **`resolveSystemPrompt`** is the single choke point called inside `agenticSearchPipeline`: default-shaped prompts (null, empty, whitespace, or any historically auto-persisted default text) resolve byte-identically to the tuned `AGENTIC_SYSTEM_PROMPT`; everything else gets `PLATFORM_CONTRACT_PROMPT` appended, explicitly overriding any legacy bracket-citation instruction.
- **Write-path hygiene**: `enableHosting` now stores `null` instead of pinning the live default text; `updateHosting` normalizes all default-shaped inputs (including empty-string API resets) to `null`; `updateHostingSchema.systemPrompt` is made nullable so GET→PATCH round-trips validate correctly.
- **Store migration (v4)** uses the broadened `isKnownDefaultPrompt` (covering CRLF variants and the 2025-03 prompt form) and correctly converts `null` to `undefined` before sending to the schema (which is `z.string().optional()`).

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core resolution logic is well-tested and the write-path normalization is consistent end to end.

The implementation is thorough: a SHA-256 pin guards the frozen legacy prompt text, a 17-case table covers every default shape and the incident class, and `use-chat.ts` converts `null` to `undefined` before it reaches the `z.string().optional()` schema. The single gap is that the `describe("isKnownDefaultPrompt")` block has no direct assertion for `LEGACY_DEFAULT_PROMPT_2025_03` — the 2025-03 variant is tested only indirectly through the `resolveSystemPrompt` table, leaving it uncovered by the more focused unit describe block.

`apps/web/test/resolve-system-prompt.test.ts` — the `isKnownDefaultPrompt` describe block is missing a direct assertion for `LEGACY_DEFAULT_PROMPT_2025_03`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/lib/agentic-search/prompts.ts | Adds `isKnownDefaultPrompt`, `resolveSystemPrompt`, `PLATFORM_CONTRACT_PROMPT`, and `LEGACY_DEFAULT_PROMPT_2025_03`. Core logic is correct: `normalizePrompt` handles CRLF/whitespace, `isKnownDefaultPrompt` covers all known stored defaults, and `resolveSystemPrompt` safely composes custom prompts with the platform contract via a non-null assertion that is sound (false branch is only reachable with a non-empty string). |
| apps/web/src/app/api/(internal-api)/hosting-chat/route.ts | Removes the local `getSystemPrompt` helper and passes the raw DB-stored prompt directly to `agenticSearchPipeline`, where `resolveSystemPrompt` handles it. Simplification is correct and reduces divergence risk. |
| apps/web/src/services/hosting/update.ts | Normalizes default-shaped `systemPrompt` inputs to `null` before persisting, including re-saves of the prefilled default and empty-string resets via the public PATCH. The three-way `undefined`/`null`/string handling is correct against Prisma's update semantics. |
| apps/web/src/services/hosting/enable.ts | Stores `null` instead of pinning the current default text, preventing the snapshot-freeze class of incident for all future enables. |
| apps/web/src/components/chat/chat-settings.store.ts | v4 migration now uses `isKnownDefaultPrompt` (covers all known defaults including CRLF variants and the 2025-03 form) instead of the narrower single-prompt comparison. `settings.systemPrompt ?? undefined` in `use-chat.ts` correctly converts `null` to `undefined`, preventing a Zod validation error against the `z.string().optional()` schema. |
| apps/web/test/resolve-system-prompt.test.ts | Comprehensive 17-case table covering identity for every default shape and composition for the incident class. The SHA-256 pin on `DEFAULT_SYSTEM_PROMPT` prevents silent edits. Minor gap: `describe("isKnownDefaultPrompt")` lacks a direct assertion for `LEGACY_DEFAULT_PROMPT_2025_03`. |

<sub>Reviews (1): Last reviewed commit: ["Make agentic citations backwards compati..."](https://github.com/agentset-ai/agentset/commit/f1b6ca907dcb9089244592ee6954be6eef2143f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41790782)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->