### PR TITLE
Fix horizontal overflow of wide math content in citation modal

### DIFF
--- a/apps/web/src/components/chat/citation-modal.tsx
+++ b/apps/web/src/components/chat/citation-modal.tsx
@@ -99,7 +99,12 @@ export function ChunksCitationModal({ chunks }: { chunks: FormattedChunk[] }) {
           return (
             <div
               key={chunk.id}
-              className={cn(index > 0 && "border-border mt-6 border-t pt-6")}
+              className={cn(
+                // DialogContent is a grid; without min-w-0 a wide chunk
+                // (e.g. a long formula) stretches past the dialog width
+                "min-w-0",
+                index > 0 && "border-border mt-6 border-t pt-6",
+              )}
             >
               {chunks.length > 1 && chunk.filename && (
                 <h3 className="mb-2 text-xs font-medium">{chunk.filename}</h3>

--- a/packages/ui/src/components/ai-elements/message.tsx
+++ b/packages/ui/src/components/ai-elements/message.tsx
@@ -110,7 +110,10 @@ export const MessageResponse = memo(
   ({ className, ...props }: MessageResponseProps) => (
     <Streamdown
       className={cn(
-        "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
+        "size-full wrap-break-word [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
+        // streamdown wraps tables and code blocks in overflow-x-auto but not
+        // KaTeX output, whose display blocks are nowrap and overflow otherwise
+        "[&_.katex-display]:overflow-x-auto [&_.katex-display]:overflow-y-hidden",
         className,
       )}
       plugins={streamdownPlugins}


### PR DESCRIPTION
Fixes #131

Wide KaTeX display math (and long unbroken strings) rendered inside the citation/source modal overflowed the dialog horizontally and broke its layout.

Root cause: Streamdown wraps tables and code blocks in overflow-x-auto containers, but KaTeX output has no overflow handling — .katex-display > .katex is a white-space: nowrap block. On top of that, DialogContent is a CSS grid, so the chunk wrapper (a grid item with default min-width: auto) stretched past the dialog's max-width.

Fix:

MessageResponse: add wrap-break-word and give .katex-display its own horizontal scroll (overflow-x-auto / overflow-y-hidden). This also fixes the same overflow in the chat and the document chunks drawer, which share the component.
Citation modal: add min-w-0 to the per-chunk wrapper so it can shrink inside the dialog grid.
Before/after screenshots attached (isolated reproduction using the exact component classes and real KaTeX rendering).

<img width="1800" height="1400" alt="before" src="https://github.com/user-attachments/assets/b166627d-424d-4b47-b951-1ee4898a743b" />
<img width="1800" height="1400" alt="after" src="https://github.com/user-attachments/assets/11b44809-8180-41c6-9c12-209b6791be78" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes horizontal overflow of wide KaTeX display-math (and long unbroken strings) in the citation modal, the chat view, and the document-chunks drawer that all share `MessageResponse`.

- `packages/ui/src/components/ai-elements/message.tsx`: adds `wrap-break-word` (Tailwind v4's `overflow-wrap: break-word`) and a scoped `[&_.katex-display]:overflow-x-auto` selector so KaTeX display blocks scroll horizontally instead of bursting past the container.
- `apps/web/src/components/chat/citation-modal.tsx`: adds `min-w-0` to the per-chunk wrapper div so it can shrink inside the CSS grid created by `DialogContent`, preventing the grid item from pushing past the dialog's `max-width`.

<h3>Confidence Score: 4/5</h3>

The changes are narrowly scoped CSS-class additions; the core logic is unchanged and both fixes are well-understood patterns for grid and overflow layout.

The `overflow-y-hidden` companion to `overflow-x-auto` suppresses the implicit scrollbar but also clips vertical overflow. KaTeX typically sizes its container accurately, yet tall or annotated math expressions can produce ink that exceeds the computed height, and `hidden` would silently cut it off.

The `overflow-y-hidden` rule in `packages/ui/src/components/ai-elements/message.tsx` deserves a second look — `overflow-y-clip` would be a safer option.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/ai-elements/message.tsx | Adds `wrap-break-word` (valid Tailwind v4 utility) and a `[&_.katex-display]:overflow-x-auto/overflow-y-hidden` selector to fix KaTeX display-math overflow in all contexts that use MessageResponse; the `overflow-y-hidden` carries a small risk of clipping unusually tall math elements. |
| apps/web/src/components/chat/citation-modal.tsx | Adds `min-w-0` to the per-chunk wrapper so it can shrink inside the CSS grid created by DialogContent — a standard and correct fix for the grid `min-width: auto` issue. |

<sub>Reviews (1): Last reviewed commit: ["Fix horizontal overflow of wide math con..."](https://github.com/agentset-ai/agentset/commit/ab0df956e6a2aa076c9c2e6c3c455dd19c5845a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41792160)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->