### PR TITLE
Add hourly cron to garbage-collect ingest jobs with no documents

### DIFF
--- a/packages/jobs/src/cron/cleanup-empty-ingest-jobs.ts
+++ b/packages/jobs/src/cron/cleanup-empty-ingest-jobs.ts
@@ -1,6 +1,6 @@
 import { logger, schedules } from "@trigger.dev/sdk";
 
-import { IngestJobStatus, NamespaceStatus } from "@agentset/db";
+import { IngestJobStatus, NamespaceStatus, Prisma } from "@agentset/db";
 
 import { getDb } from "../db";
 import { emitBulkIngestJobWebhooks } from "../webhook";
@@ -43,6 +43,8 @@ export const cleanupEmptyIngestJobsCronJob = schedules.task({
   run: async () => {
     const db = getDb();
 
+    const cutoff = new Date(Date.now() - GRACE_MS);
+
     // `documents: { none: {} }` compiles to NOT EXISTS, which probes the
     // document (ingestJobId, ...) index without fetching document rows. The
     // namespace ACTIVE guard keeps the sweep out of namespaces that are
@@ -50,7 +52,7 @@ export const cleanupEmptyIngestJobsCronJob = schedules.task({
     // suppresses webhooks for them).
     const emptyJobFilter = {
       status: { in: DELETABLE_STATUSES },
-      updatedAt: { lt: new Date(Date.now() - GRACE_MS) },
+      updatedAt: { lt: cutoff },
       documents: { none: {} },
       namespace: { status: NamespaceStatus.ACTIVE },
     };
@@ -58,6 +60,7 @@ export const cleanupEmptyIngestJobsCronJob = schedules.task({
     let totalDeleted = 0;
     let totalSkipped = 0;
     let batches = 0;
+    let lastBatchFull = false;
     // Deleted rows never reappear, but keyset pagination (id > cursor) still
     // guarantees progress if a job is skipped by the delete-time re-check —
     // otherwise a permanently-skipped job would be refetched forever.
@@ -80,7 +83,6 @@ export const cleanupEmptyIngestJobsCronJob = schedules.task({
         select: {
           id: true,
           name: true,
-          status: true,
           error: true,
           createdAt: true,
           updatedAt: true,
@@ -91,6 +93,7 @@ export const cleanupEmptyIngestJobsCronJob = schedules.task({
 
       if (jobs.length === 0) break;
       batches++;
+      lastBatchFull = jobs.length === BATCH_SIZE;
       cursor = jobs[jobs.length - 1]!.id;
 
       // group by namespace so counters are decremented once per namespace
@@ -108,35 +111,34 @@ export const cleanupEmptyIngestJobsCronJob = schedules.task({
         let deletedIds: string[] = [];
         try {
           deletedIds = await db.$transaction(async (tx) => {
-            // re-check the FULL filter at delete time: a job that gained a
-            // concurrent deleteIngestJob run (status -> DELETING), was
-            // touched since the scan (fresh updatedAt resets its grace), or
-            // sits in a namespace that started tearing down is skipped
-            const candidates = await tx.ingestJob.findMany({
-              where: { id: { in: ids }, ...emptyJobFilter },
-              select: { id: true },
-            });
-            if (candidates.length === 0) return [];
-
-            const candidateIds = candidates.map((candidate) => candidate.id);
-            const { count } = await tx.ingestJob.deleteMany({
-              where: { id: { in: candidateIds }, ...emptyJobFilter },
-            });
-
-            // rare: a row changed between the two statements — re-derive
-            // exactly which ids this transaction deleted, so webhooks are
-            // emitted for precisely those and counters match reality
-            let deleted = candidateIds;
-            if (count !== candidateIds.length) {
-              const survivors = await tx.ingestJob.findMany({
-                where: { id: { in: candidateIds } },
-                select: { id: true },
-              });
-              const surviving = new Set(
-                survivors.map((survivor) => survivor.id),
-              );
-              deleted = candidateIds.filter((id) => !surviving.has(id));
-            }
+            // Single DELETE ... RETURNING re-checks the FULL scan filter at
+            // delete time and reports exactly the rows THIS statement
+            // removed: a job that gained a concurrent deleteIngestJob run
+            // (status -> DELETING), was touched since the scan (fresh
+            // updatedAt resets its grace), or sits in a namespace that
+            // started tearing down is skipped. Deriving the deleted set from
+            // a separate re-select would misattribute rows deleted by a
+            // concurrent committed transaction (double-decrementing counters
+            // and double-emitting webhooks); RETURNING cannot. Raw SQL
+            // because Prisma has no deleteManyAndReturn; the ::text casts
+            // keep DELETABLE_STATUSES as the single source of truth (bound
+            // text params don't coerce to the "IngestJobStatus" enum).
+            const deletedRows = await tx.$queryRaw<{ id: string }[]>`
+              DELETE FROM "ingest_job" AS ij
+              WHERE ij."id" IN (${Prisma.join(ids)})
+                AND ij."status"::text IN (${Prisma.join(DELETABLE_STATUSES)})
+                AND ij."updatedAt" < ${cutoff}
+                AND NOT EXISTS (
+                  SELECT 1 FROM "document" d WHERE d."ingestJobId" = ij."id"
+                )
+                AND EXISTS (
+                  SELECT 1 FROM "namespace" n
+                  WHERE n."id" = ij."namespaceId"
+                    AND n."status" = 'ACTIVE'
+                )
+              RETURNING ij."id"
+            `;
+            const deleted = deletedRows.map((row) => row.id);
 
             if (deleted.length > 0) {
               await tx.namespace.update({
@@ -210,9 +212,11 @@ export const cleanupEmptyIngestJobsCronJob = schedules.task({
       }
     }
 
-    if (batches >= MAX_BATCHES) {
+    // a non-full final page means the sweep finished naturally even if it
+    // landed exactly on the cap
+    if (batches >= MAX_BATCHES && lastBatchFull) {
       logger.warn(
-        "Cleanup stopped at the batch cap with jobs remaining; the next run will continue",
+        "Cleanup stopped at the batch cap with jobs likely remaining; the next run will continue",
         { batches, totalDeleted },
       );
     }

--- a/packages/jobs/src/cron/cleanup-empty-ingest-jobs.ts
+++ b/packages/jobs/src/cron/cleanup-empty-ingest-jobs.ts
@@ -1,0 +1,232 @@
+import { logger, schedules } from "@trigger.dev/sdk";
+
+import { IngestJobStatus, NamespaceStatus } from "@agentset/db";
+
+import { getDb } from "../db";
+import { emitBulkIngestJobWebhooks } from "../webhook";
+
+const BATCH_SIZE = 100;
+// backstop against a runaway loop; 1000 batches = 100k jobs per run
+const MAX_BATCHES = 1000;
+
+// Deleting a document (or all of a job's documents) doesn't delete the parent
+// ingest job, so jobs whose documents were all deleted linger forever (and
+// keep squatting on their namespace-unique externalId). This cron
+// garbage-collects them.
+//
+// Only terminal statuses are eligible:
+// - in-flight jobs (BACKLOG..PROCESSING) legitimately have no documents YET
+// - DELETING/CANCELLING/QUEUED_FOR_DELETE are owned by another workflow that
+//   deletes the row and updates counters itself — touching them here would
+//   double-decrement totalIngestJobs
+const DELETABLE_STATUSES = [
+  IngestJobStatus.COMPLETED,
+  IngestJobStatus.FAILED,
+  IngestJobStatus.CANCELLED,
+];
+
+// Empty jobs are kept for a day before collection so that (a) jobs that just
+// transitioned aren't raced, (b) a job that legitimately completed with zero
+// documents (e.g. a crawl that matched nothing) or failed before producing
+// documents stays visible in the dashboard/API long enough for the user to
+// see what happened, and (c) API consumers polling a terminal job get a full
+// day to read its final status before the id starts returning 404.
+const GRACE_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export const cleanupEmptyIngestJobsCronJob = schedules.task({
+  id: "cleanup-empty-ingest-jobs",
+  // Runs hourly (0 * * * *)
+  cron: "0 * * * *",
+  // the loop is idempotent, but there's no point running two sweeps at once
+  queue: { concurrencyLimit: 1 },
+  maxDuration: 60 * 30, // 30 minutes
+  run: async () => {
+    const db = getDb();
+
+    // `documents: { none: {} }` compiles to NOT EXISTS, which probes the
+    // document (ingestJobId, ...) index without fetching document rows. The
+    // namespace ACTIVE guard keeps the sweep out of namespaces that are
+    // mid-teardown: deleteNamespace owns those jobs (and deliberately
+    // suppresses webhooks for them).
+    const emptyJobFilter = {
+      status: { in: DELETABLE_STATUSES },
+      updatedAt: { lt: new Date(Date.now() - GRACE_MS) },
+      documents: { none: {} },
+      namespace: { status: NamespaceStatus.ACTIVE },
+    };
+
+    let totalDeleted = 0;
+    let totalSkipped = 0;
+    let batches = 0;
+    // Deleted rows never reappear, but keyset pagination (id > cursor) still
+    // guarantees progress if a job is skipped by the delete-time re-check —
+    // otherwise a permanently-skipped job would be refetched forever.
+    let cursor: string | undefined;
+
+    while (batches < MAX_BATCHES) {
+      // Walks the primary key in order; each page stops as soon as it fills,
+      // but the terminal (non-full) page has to visit every remaining
+      // candidate row — in steady state (few matches) each run costs one
+      // pass over the terminal jobs' NOT EXISTS probes. Fine at current
+      // table sizes; if it ever shows up in db metrics, move the cleanup
+      // into the document-deletion path and keep this as a backstop.
+      const jobs = await db.ingestJob.findMany({
+        where: {
+          ...emptyJobFilter,
+          ...(cursor ? { id: { gt: cursor } } : {}),
+        },
+        orderBy: { id: "asc" },
+        take: BATCH_SIZE,
+        select: {
+          id: true,
+          name: true,
+          status: true,
+          error: true,
+          createdAt: true,
+          updatedAt: true,
+          namespaceId: true,
+          namespace: { select: { organizationId: true } },
+        },
+      });
+
+      if (jobs.length === 0) break;
+      batches++;
+      cursor = jobs[jobs.length - 1]!.id;
+
+      // group by namespace so counters are decremented once per namespace
+      // instead of once per job
+      const byNamespace = new Map<string, typeof jobs>();
+      for (const job of jobs) {
+        const group = byNamespace.get(job.namespaceId);
+        if (group) group.push(job);
+        else byNamespace.set(job.namespaceId, [job]);
+      }
+
+      for (const [namespaceId, nsJobs] of byNamespace) {
+        const ids = nsJobs.map((job) => job.id);
+
+        let deletedIds: string[] = [];
+        try {
+          deletedIds = await db.$transaction(async (tx) => {
+            // re-check the FULL filter at delete time: a job that gained a
+            // concurrent deleteIngestJob run (status -> DELETING), was
+            // touched since the scan (fresh updatedAt resets its grace), or
+            // sits in a namespace that started tearing down is skipped
+            const candidates = await tx.ingestJob.findMany({
+              where: { id: { in: ids }, ...emptyJobFilter },
+              select: { id: true },
+            });
+            if (candidates.length === 0) return [];
+
+            const candidateIds = candidates.map((candidate) => candidate.id);
+            const { count } = await tx.ingestJob.deleteMany({
+              where: { id: { in: candidateIds }, ...emptyJobFilter },
+            });
+
+            // rare: a row changed between the two statements — re-derive
+            // exactly which ids this transaction deleted, so webhooks are
+            // emitted for precisely those and counters match reality
+            let deleted = candidateIds;
+            if (count !== candidateIds.length) {
+              const survivors = await tx.ingestJob.findMany({
+                where: { id: { in: candidateIds } },
+                select: { id: true },
+              });
+              const surviving = new Set(
+                survivors.map((survivor) => survivor.id),
+              );
+              deleted = candidateIds.filter((id) => !surviving.has(id));
+            }
+
+            if (deleted.length > 0) {
+              await tx.namespace.update({
+                where: { id: namespaceId },
+                data: {
+                  totalIngestJobs: { decrement: deleted.length },
+                  organization: {
+                    update: { totalIngestJobs: { decrement: deleted.length } },
+                  },
+                },
+                select: { id: true },
+              });
+            }
+
+            return deleted;
+          });
+        } catch (error) {
+          // e.g. the namespace itself was deleted mid-sweep (its jobs are
+          // cascade-deleted with it) — skip the group, the next run picks up
+          // anything that survived
+          logger.error("Failed to clean up empty ingest jobs for namespace", {
+            namespaceId,
+            jobIds: ids,
+            error,
+          });
+          continue;
+        }
+
+        totalDeleted += deletedIds.length;
+
+        if (deletedIds.length !== nsJobs.length) {
+          // raced jobs are skipped here; whichever deletion path claimed
+          // them emits their webhook
+          totalSkipped += nsJobs.length - deletedIds.length;
+          logger.warn("Skipped concurrently-modified ingest jobs", {
+            namespaceId,
+            expected: nsJobs.length,
+            deleted: deletedIds.length,
+          });
+        }
+
+        if (deletedIds.length === 0) continue;
+
+        const deletedIdSet = new Set(deletedIds);
+        try {
+          await emitBulkIngestJobWebhooks({
+            trigger: "ingest_job.deleted",
+            organizationId: nsJobs[0]!.namespace.organizationId,
+            namespaceId,
+            ingestJobs: nsJobs
+              .filter((job) => deletedIdSet.has(job.id))
+              .map((job) => ({
+                id: job.id,
+                name: job.name,
+                namespaceId: job.namespaceId,
+                organizationId: job.namespace.organizationId,
+                status: "DELETING",
+                error: job.error,
+                createdAt: job.createdAt,
+                updatedAt: new Date(),
+              })),
+          });
+        } catch (error) {
+          // the jobs are already deleted; failing the run would only re-sweep
+          logger.error("Failed to emit ingest_job.deleted webhooks", {
+            namespaceId,
+            jobIds: deletedIds,
+            error,
+          });
+        }
+      }
+    }
+
+    if (batches >= MAX_BATCHES) {
+      logger.warn(
+        "Cleanup stopped at the batch cap with jobs remaining; the next run will continue",
+        { batches, totalDeleted },
+      );
+    }
+
+    logger.info("Empty ingest job cleanup finished", {
+      totalDeleted,
+      totalSkipped,
+      batches,
+    });
+
+    return {
+      deletedJobs: totalDeleted,
+      skippedJobs: totalSkipped,
+      batches,
+    };
+  },
+});

--- a/packages/jobs/src/webhook.ts
+++ b/packages/jobs/src/webhook.ts
@@ -6,6 +6,7 @@ import type {
 } from "@agentset/webhooks";
 import {
   emitBulkDocumentWebhooks as emitBulkDocumentWebhooksBase,
+  emitBulkIngestJobWebhooks as emitBulkIngestJobWebhooksBase,
   emitDocumentWebhook as emitDocumentWebhookBase,
   emitIngestJobWebhook as emitIngestJobWebhookBase,
 } from "@agentset/webhooks/server";
@@ -42,6 +43,32 @@ export const emitIngestJobWebhook = async ({
     triggerSendWebhook,
     trigger,
     ingestJob,
+  });
+};
+
+/**
+ * Emit webhooks for multiple ingest jobs in bulk (jobs context).
+ * Fetches webhooks once and sends to all matching ingest jobs.
+ */
+export const emitBulkIngestJobWebhooks = async ({
+  trigger,
+  ingestJobs,
+  organizationId,
+  namespaceId,
+}: {
+  trigger: IngestJobWebhookTrigger;
+  ingestJobs: IngestJobEventPayload[];
+  organizationId: string;
+  namespaceId?: string;
+}) => {
+  const db = getDb();
+  return emitBulkIngestJobWebhooksBase({
+    db,
+    triggerSendWebhook,
+    trigger,
+    ingestJobs,
+    organizationId,
+    namespaceId,
   });
 };
 

--- a/packages/webhooks/src/emit.ts
+++ b/packages/webhooks/src/emit.ts
@@ -314,6 +314,57 @@ export const emitBulkDocumentWebhooks = async ({
   );
 };
 
+export interface EmitBulkIngestJobWebhooksParams {
+  db: PrismaClient;
+  triggerSendWebhook: TriggerSendWebhookFn;
+  trigger: IngestJobWebhookTrigger;
+  ingestJobs: IngestJobEventPayload[];
+  organizationId: string;
+  namespaceId?: string;
+}
+
+/**
+ * Emit webhooks for multiple ingest jobs in bulk.
+ * Fetches webhooks once and sends to all matching ingest jobs.
+ */
+export const emitBulkIngestJobWebhooks = async ({
+  db,
+  triggerSendWebhook,
+  trigger,
+  ingestJobs,
+  organizationId,
+  namespaceId,
+}: EmitBulkIngestJobWebhooksParams) => {
+  if (ingestJobs.length === 0) {
+    return;
+  }
+
+  // Fetch webhooks once for all ingest jobs
+  const webhooks = await getActiveWebhooks({
+    db,
+    organizationId,
+    trigger,
+    namespaceId,
+  });
+
+  if (webhooks.length === 0) {
+    return;
+  }
+
+  // Send webhooks for each ingest job using the cached webhook list
+  await Promise.all(
+    ingestJobs.map((ingestJob) => {
+      const data = transformIngestJobEventData(ingestJob);
+      return sendWebhooksWithCache({
+        triggerSendWebhook,
+        trigger,
+        webhooks,
+        data,
+      });
+    }),
+  );
+};
+
 export interface EmitIngestJobWebhookParams {
   db: PrismaClient;
   triggerSendWebhook: TriggerSendWebhookFn;


### PR DESCRIPTION
## Why

Deleting documents (individually or "delete all") never deletes the parent ingest job — only `deleteIngestJob` removes job rows. So jobs whose documents were all deleted linger forever. Besides the stale rows, they permanently squat on their `@@unique([namespaceId, externalId])` slot, blocking that externalId from ever being reused.

## What

A new hourly trigger.dev cron (`cleanup-empty-ingest-jobs`, `0 * * * *`) sweeps ingest jobs that have **no documents** and deletes them, keeping `namespace.totalIngestJobs` / `organization.totalIngestJobs` in sync and emitting `ingest_job.deleted` webhooks.

**Eligibility** — a job is only collected when all of these hold:
- terminal status (`COMPLETED` / `FAILED` / `CANCELLED`). In-flight jobs legitimately have no documents *yet*; `DELETING`/`CANCELLING`/`QUEUED_FOR_DELETE` are owned by another workflow that deletes the row and updates counters itself.
- zero document rows (`documents: { none: {} }` → `NOT EXISTS`, probed via the existing `document(ingestJobId, …)` index).
- `updatedAt` older than **24h**. The grace keeps zero-result crawls and failed jobs (the user's error surface) visible for a day, and gives API consumers polling a terminal job a day to read its final status before the id 404s.
- namespace is `ACTIVE` — a namespace mid-teardown owns its jobs (and deliberately suppresses webhooks for them).

**Efficiency / correctness on critical infra:**
- Keyset pagination (`id > cursor`, PK order) in batches of 100, hard cap of 1000 batches/run with a warning log — the cap and any skips are logged, never silent.
- Jobs are grouped **per namespace**: one guarded `deleteMany` + one grouped counter decrement (namespace + nested org) per group, instead of per-job writes.
- The **full filter is re-checked inside the delete transaction**, so a job that was concurrently claimed by `deleteIngestJob` (status → `DELETING`), touched since the scan (fresh `updatedAt` resets its grace), or whose namespace started tearing down is skipped — no double-decrements, no deleting under an active workflow.
- Counters and webhooks are driven by the **exact set of ids the transaction deleted** (survivor re-select only on the rare count mismatch), so raced jobs get their webhook from whichever path actually deleted them — nothing is dropped and nothing is emitted twice.
- Webhook emission uses a new `emitBulkIngestJobWebhooks` helper that fetches the org's webhook list once per namespace group (mirrors the existing `emitBulkDocumentWebhooks`), early-exits when the org has no webhooks, and is best-effort after commit (failure logs instead of re-sweeping already-deleted rows).
- `queue: { concurrencyLimit: 1 }` so hourly runs never overlap; the loop is idempotent under retries regardless.

## Notes / follow-ups

- **No index added on purpose:** terminal statuses are most of the table, so a `status` index has poor selectivity; the dominant cost is the `NOT EXISTS` probes, which no ingest_job index removes. In steady state each run costs one pass of index probes over terminal jobs — fine at current table sizes. If it ever shows up in db metrics, the better shape is event-driven: check-and-delete the parent job in the document-deletion path and keep this cron as a backstop.
- The 24h grace is one constant (`GRACE_MS`) — easy to tune if we want empties gone faster.
- Pre-existing sliver worth a separate fix: the re-ingest endpoints trigger the task before flipping job status, so a job deleted between those two steps can 500. The delete-time grace re-check makes this near-impossible to hit via this cron, but reordering the endpoint would close it fully.
- Typecheck/lint: the touched packages pass; the only failures are the pre-existing `packages/emails` `--jsx` errors, identical on `main`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an hourly Trigger.dev cron job that garbage-collects ingest jobs whose documents were all deleted — a gap where the parent job row lingered indefinitely and permanently occupied its `@@unique([namespaceId, externalId])` slot. It also introduces `emitBulkIngestJobWebhooks` as a clean mirror of the existing `emitBulkDocumentWebhooks` helper.

- The cron uses keyset pagination with a hard cap, a `DELETE ... RETURNING` that re-checks every eligibility condition atomically inside a transaction, and per-namespace batched counter decrements — making it correct under concurrent `deleteIngestJob` runs.
- Jobs are only collected after a 24-hour grace period and only when the namespace is `ACTIVE`, preventing races with in-flight workflows and namespace teardown.
- `queue: { concurrencyLimit: 1 }` ensures runs never overlap; the task directory is already included in `trigger.config.ts` so no registration change is needed.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the cron is idempotent, isolated behind a concurrency limit, and carefully guards against double-decrements via RETURNING-based accounting.

The concurrency design is thorough: the DELETE … RETURNING re-check eliminates the double-decrement/double-webhook class of bugs, keyset pagination guarantees forward progress even when jobs are skipped, and the catch block correctly absorbs mid-sweep namespace teardown. The one new finding is a minor maintainability nit (raw 'ACTIVE' string in SQL instead of the imported constant). All previously identified concerns have been addressed in the current code.

No files require special attention; cleanup-empty-ingest-jobs.ts has the most logic but its concurrency guards are well-reasoned.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/jobs/src/cron/cleanup-empty-ingest-jobs.ts | New hourly cron that garbage-collects empty ingest jobs with keyset pagination, a RETURNING-based atomic delete, and per-namespace counter decrements; well-designed with strong concurrency guards, though the webhook payload hardcodes `status: "DELETING"` regardless of the actual terminal status |
| packages/jobs/src/webhook.ts | Adds `emitBulkIngestJobWebhooks` wrapper mirroring the existing `emitBulkDocumentWebhooks` pattern; thin delegation to the base implementation, no issues |
| packages/webhooks/src/emit.ts | Adds `emitBulkIngestJobWebhooks` as a direct mirror of `emitBulkDocumentWebhooks`; fetches webhooks once per namespace group, filters and fans out via `Promise.all`, consistent with existing patterns |

<sub>Reviews (2): Last reviewed commit: ["Fix deleted-set attribution race and rev..."](https://github.com/agentset-ai/agentset/commit/f075fd9395e29dad4ccc563805988fbc0b609f08) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44777702)</sub>

<!-- /greptile_comment -->